### PR TITLE
fix: resolve config.yaml auto-creation blocking environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,17 +18,24 @@ services:
       # - ./config:/app/config
       # - ./data:/app/data
       # - ./logs:/app/logs  # Optional: access logs locally
-    # Environment variables for configuration (optional - takes precedence after config.yaml)
+    # Environment variables for configuration (recommended for Docker)
     # Uncomment and customize the values below to use environment variable configuration
-    # NOTE: config.yaml values take highest precedence, followed by environment variables, then defaults
+    #
+    # 🚀 CONFIGURATION MODES:
+    # 1. Environment Variables (no config.yaml needed) - Perfect for Docker!
+    # 2. YAML Configuration (create config/config.yaml manually) - Advanced features
+    #
+    # 📋 PRIORITY ORDER (if both exist):
+    # 1. config.yaml values (highest) - if config.yaml exists
+    # 2. Environment variables (fallback) - fills missing config.yaml values
+    # 3. Built-in defaults (lowest)
     #
     # ⚠️  LIMITATIONS: Some advanced features require config.yaml:
     #     - Library filtering (include/exclude arrays)
     #     - Reread detection configuration (nested settings)
     #     - Per-user library filtering
     #
-    # 💡 Use environment variables for: Basic setups, Docker deployments, simple configuration
-    # 💡 Use config.yaml for: Library filtering, multi-user advanced setups, complex family configurations
+    # 💡 Recommendation: Use environment variables for most setups - no file editing needed!
     environment:
       # Default environment - prevents empty environment mapping error
       NODE_ENV: 'production'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -99,34 +99,33 @@ if [ ! -f "/app/config/config.yaml.example" ]; then
     echo "✅ Sample config available at ./config/config.yaml.example"
 fi
 
-# Auto-create config.yaml from example if it doesn't exist
-if [ ! -f "/app/config/config.yaml" ]; then
-    echo "🔧 Creating config.yaml from example template..."
-    cp /app/config/config.yaml.example /app/config/config.yaml
-    echo "✅ Created config.yaml - please edit it with your API credentials"
-    echo "💡 Container will restart automatically when you save changes to config.yaml"
-    echo "📝 Edit: ./config/config.yaml"
-    
-    # Provide helpful instructions based on volume setup
+# Show configuration guidance without auto-creating config.yaml
+echo ""
+echo "🚀 SHELFBRIDGE CONFIGURATION OPTIONS:"
+echo ""
+
+if [ -f "/app/config/config.yaml" ]; then
+    echo "📁 Using YAML configuration file: /app/config/config.yaml"
+    echo "   • YAML configuration takes highest priority"
+    echo "   • Environment variables will only fill missing values"
+elif [ -n "$SHELFBRIDGE_USER_0_ID" ]; then
+    echo "🔧 Using environment variables for configuration"
+    echo "   • No config.yaml file found - using SHELFBRIDGE_* environment variables"
+    echo "   • This is perfect for container deployments!"
+else
+    echo "⚠️  No configuration detected!"
     echo ""
-    echo "🚀 CONFIGURATION OPTIONS:"
+    echo "📝 OPTION 1: Create YAML configuration file"
+    echo "   • Copy: cp /app/config/config.yaml.example /app/config/config.yaml"
+    echo "   • Edit: /app/config/config.yaml with your API credentials"
     echo ""
-    if mountpoint -q /app/config 2>/dev/null; then
-        echo "📁 Using Docker volume for config (zero-config setup)"
-        echo "   • Config file: Use docker exec to edit inside container"
-        echo "   • OR switch to local directories for easier editing (see docker-compose.yml comments)"
-    else
-        echo "📁 Using local directory mount for config"
-        echo "   • Config file: Edit ./config/config.yaml on your host machine"
-        echo "   • Logs: Available in ./logs/ directory (if mounted)"
-        echo "   • Data: Available in ./data/ directory (if mounted)"
-    fi
+    echo "🔧 OPTION 2: Use environment variables (recommended for Docker)"
+    echo "   • Set SHELFBRIDGE_USER_0_ID, SHELFBRIDGE_USER_0_ABS_URL, etc."
+    echo "   • No config file needed - perfect for containers!"
     echo ""
-    echo "🔧 ALTERNATIVE: Use environment variables in docker-compose.yml"
-    echo "   • Uncomment and set SHELFBRIDGE_USER_0_* variables"
-    echo "   • No config file editing required"
-    echo ""
+    echo "📖 See documentation for complete setup guide"
 fi
+echo ""
 
 # Check if config.yaml still contains placeholder values
 if [ -f "/app/config/config.yaml" ]; then
@@ -137,25 +136,20 @@ if [ -f "/app/config/config.yaml" ]; then
         echo ""
         echo "❌ CONFIGURATION ERROR: Placeholder values detected in config.yaml"
         echo ""
-        echo "🔧 PLEASE EDIT YOUR CONFIG FILE:"
+        echo "🔧 CHOOSE YOUR CONFIGURATION METHOD:"
         echo ""
-        echo "1. Edit config/config.yaml with your actual credentials:"
-        echo "   • abs_url: Your Audiobookshelf server URL"
-        echo "   • abs_token: Get from Audiobookshelf Settings > Users > API Token"
-        echo "   • hardcover_token: Get from https://hardcover.app/account/developer"
-        echo "   • id: Choose a unique user identifier"
+        echo "📝 OPTION 1: Edit the existing config.yaml file"
+        echo "   • Replace placeholder values with your actual credentials:"
+        echo "     - abs_url: Your Audiobookshelf server URL"
+        echo "     - abs_token: Get from Audiobookshelf Settings > Users > API Token"
+        echo "     - hardcover_token: Get from https://hardcover.app/account/developer"
+        echo "     - id: Choose a unique user identifier"
+        echo "   • Save the file - container will restart automatically"
         echo ""
-        echo "2. Save the file - the container will restart automatically"
-        echo ""
-        echo "📝 Example config.yaml:"
-        echo "global:"
-        echo "  min_progress_threshold: 5.0"
-        echo "  # ... other settings ..."
-        echo "users:"
-        echo "  - id: alice"
-        echo "    abs_url: https://audiobookshelf.mydomain.com"
-        echo "    abs_token: your_actual_abs_token_here"
-        echo "    hardcover_token: your_actual_hardcover_token_here"
+        echo "🔧 OPTION 2: Switch to environment variables (easier for Docker)"
+        echo "   • Delete config.yaml: rm /app/config/config.yaml"
+        echo "   • Set environment variables: SHELFBRIDGE_USER_0_ID, SHELFBRIDGE_USER_0_ABS_URL, etc."
+        echo "   • Restart container"
         echo ""
         echo "💡 Use 'node src/main.js validate' to check your configuration"
         echo ""

--- a/wiki/user-guides/Docker-Setup.md
+++ b/wiki/user-guides/Docker-Setup.md
@@ -66,52 +66,42 @@ docker-compose up -d
 
 - ✅ **Folders created**: `config/`, `data/`, and `logs/` directories
 - ✅ **Config template**: `config.yaml.example` copied for reference
-- ✅ **Base config**: `config.yaml` created from template
-- ⚠️ **Container exits**: Stops gracefully until you edit the config with real credentials
+- ℹ️ **Smart configuration**: Detects your preferred configuration method
+- ⚠️ **Container guides you**: Shows clear instructions if configuration is missing
 
-**Next: Edit your configuration**
+**Next: Choose your configuration method**
 
-The container will show instructions for editing your config. You have two options:
+ShelfBridge will detect your configuration and guide you. You have two excellent options:
 
-**Option 1: Named Volumes (Default - Zero Config)**
+**Option 1: Environment Variables (Recommended - No File Editing!)**
 
 ```bash
-# Since container exits with invalid config, you need to use environment variables
-# OR edit via temporary container:
-
-# Method A: Use environment variables (Recommended)
 # Edit docker-compose.yml and uncomment/set these variables:
 # SHELFBRIDGE_USER_0_ID: "your_username"
 # SHELFBRIDGE_USER_0_ABS_URL: "https://your-abs-server.com"
 # SHELFBRIDGE_USER_0_ABS_TOKEN: "your_abs_token"
 # SHELFBRIDGE_USER_0_HARDCOVER_TOKEN: "your_hardcover_token"
 
-# Method B: Edit via temporary container
+# That's it! No config file editing needed.
+docker-compose up -d
+```
+
+**Option 2: YAML Configuration File (Advanced Features)**
+
+```bash
+# Create config file manually from template
+docker run --rm -v shelfbridge-config:/app/config \
+  ghcr.io/rohit-purandare/shelfbridge:latest \
+  cp /app/config/config.yaml.example /app/config/config.yaml
+
+# Edit via temporary container
 docker run --rm -it \
   -v shelfbridge-config:/app/config \
   ghcr.io/rohit-purandare/shelfbridge:latest \
   sh -c "nano /app/config/config.yaml"
 
-# Then restart your main container
+# Start your main container
 docker-compose up -d
-```
-
-**Option 2: Local Directories (Easier Editing)**
-
-```bash
-# Stop container
-docker-compose down
-
-# Edit docker-compose.yml:
-# - Comment out the named volume lines
-# - Uncomment the local directory lines
-
-# Start with local directories
-docker-compose up -d
-
-# Now edit config directly on your host machine
-nano config/config.yaml
-docker-compose restart
 ```
 
 **That's it!** ShelfBridge is now running with automatic scheduling.
@@ -168,26 +158,42 @@ docker-compose ps
 
 **Step 3: Configure**
 
-````bash
-# Edit configuration (auto-created from template)
-# Edit the config/config.yaml file on your host machine using your preferred text editor (e.g., VS Code, nano, vim, Notepad).
-# Once you have updated and saved the configuration, (re)start the container:
-docker-compose up -d
+Choose your preferred configuration method:
 
-> **Note:** The container will exit if the config file is missing or invalid. Always edit the config file on your host, not inside the container.
+**Option A: Environment Variables (Recommended)**
 
-Replace placeholder values:
-```yaml
+```bash
+# Edit docker-compose.yml and uncomment these lines:
+environment:
+  SHELFBRIDGE_USER_0_ID: "your_username"
+  SHELFBRIDGE_USER_0_ABS_URL: "https://your-abs-server.com"
+  SHELFBRIDGE_USER_0_ABS_TOKEN: "your_actual_abs_token"
+  SHELFBRIDGE_USER_0_HARDCOVER_TOKEN: "your_actual_hardcover_token"
+
+# That's it! No file editing needed.
+```
+
+**Option B: YAML Configuration File (Advanced)**
+
+```bash
+# Create config file from template
+docker exec -it shelfbridge cp /app/config/config.yaml.example /app/config/config.yaml
+
+# Edit configuration file
+docker exec -it shelfbridge nano /app/config/config.yaml
+# Replace placeholder values with your actual credentials
+
+# Example config.yaml:
 global:
   min_progress_threshold: 5.0
   auto_add_books: false
 
 users:
   - id: your_username
-    abs_url: https://your-audiobookshelf-server.com
-    abs_token: your_actual_audiobookshelf_token
+    abs_url: https://your-abs-server.com
+    abs_token: your_actual_abs_token
     hardcover_token: your_actual_hardcover_token
-````
+```
 
 **Step 4: Restart and Verify**
 
@@ -263,13 +269,13 @@ volumes:
 
 **Key features:**
 
-- ✅ **Automatic setup**: All folders and config files created automatically
+- ✅ **Automatic setup**: All folders and config templates created automatically
 - ✅ **Flexible volumes**: Easy switch between named volumes and local directories
-- ✅ **Environment config**: Optional environment variable configuration
+- ✅ **Environment config**: Environment variables work perfectly without config files
 - ✅ **Health checks**: Built-in container health monitoring
-- ⚠️ **Config validation**: Container exits gracefully with placeholder values (prevents restart loops)
+- ⚠️ **Smart configuration**: Detects and guides you to your preferred config method
 
-> **Note:** The container uses `restart: 'no'` and will exit when it detects placeholder values in config.yaml. This prevents endless restart loops and gives you clear instructions on what to fix. Once you edit the config with real credentials, restart the container with `docker-compose up -d`.
+> **Note:** The container uses `restart: 'no'` and provides clear guidance on configuration options. Choose environment variables for easy Docker setup, or create config.yaml manually for advanced features. Once configured, restart with `docker-compose up -d`.
 
 ## 🔧 Manual Docker Run
 
@@ -290,12 +296,16 @@ docker run -d \
   -v shelfbridge-data:/app/data \
   ghcr.io/rohit-purandare/shelfbridge:latest
 
-# Configure
-# Edit the config/config.yaml file on your host machine using your preferred text editor (e.g., VS Code, nano, vim, Notepad).
-# Once you have updated and saved the configuration, (re)start the container:
-docker-compose up -d
+# Configure (choose one method)
+# Option A: Environment variables (add to docker run command):
+# -e SHELFBRIDGE_USER_0_ID="your_username" \
+# -e SHELFBRIDGE_USER_0_ABS_URL="https://your-abs-server.com" \
+# -e SHELFBRIDGE_USER_0_ABS_TOKEN="your_abs_token" \
+# -e SHELFBRIDGE_USER_0_HARDCOVER_TOKEN="your_hardcover_token" \
 
-> **Note:** The container will exit if the config file is missing or invalid. Always edit the config file on your host, not inside the container.
+# Option B: Create and edit config file
+# docker exec -it shelfbridge cp /app/config/config.yaml.example /app/config/config.yaml
+# docker exec -it shelfbridge nano /app/config/config.yaml
 
 # Restart to apply config
 docker restart shelfbridge
@@ -317,12 +327,16 @@ docker run -d \
   ghcr.io/rohit-purandare/shelfbridge:latest
 
 # Container automatically creates:
-# - ./config/ directory with config.yaml and config.yaml.example
+# - ./config/ directory with config.yaml.example template
 # - ./data/ directory for cache and sync data
 # - ./logs/ directory for application logs
 
-# Edit config file directly on your host
-nano config/config.yaml
+# Configure (choose one method):
+# Option A: Environment variables (add -e flags to docker run above)
+# Option B: Create and edit config file manually
+# cp config/config.yaml.example config/config.yaml
+# nano config/config.yaml
+
 docker restart shelfbridge
 ```
 


### PR DESCRIPTION
- Remove auto-creation of config.yaml from docker-entrypoint.sh
- Environment variables now work correctly when no config.yaml exists
- YAML configuration still takes priority when manually created
- Improve configuration guidance and error messaging
- Update docker-compose.yml comments for clarity
- Update Docker setup documentation to reflect new behavior

Fixes priority conflict where auto-created placeholder config.yaml would override environment variables, making env-only setup impossible.