### PR TITLE
fix: add missing _needsBookIdLookup flag for cached title/author matches

### DIFF
--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -443,6 +443,7 @@ export class SyncManager {
           },
           _isSearchResult: true,
           _matchingScore: { totalScore: 85, confidence: 'high' }, // Cached results are trusted
+          _needsBookIdLookup: true, // Cached results don't include book ID, need lookup
         };
       }
 


### PR DESCRIPTION
Resolves 'Missing required IDs for adding title/author matched book to library' error that occurred when books were found via cached title/author search but lacked book ID.

The cached match object creation was missing the _needsBookIdLookup flag, preventing the system from triggering book ID lookup when needed. This fix ensures cached title/author matches properly trigger book ID resolution.

- Add _needsBookIdLookup: true to cached match objects in _findBookByTitleAuthor
- Cached results now follow same lookup logic as fresh search results
- No cache clearing required - fix works immediately with existing cache data
- Resolves bookId=undefined errors for cached title/author matched books