### PR TITLE
ci: fix Docker artifact chain using GitHub API for both Test and Publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,6 +73,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Find Docker Build workflow run
+        if: github.event_name == 'workflow_run'
+        id: find-build-run
+        run: |
+          echo "🔍 Finding Docker Build workflow run for this commit..."
+
+          # Get the commit SHA from the triggering workflow
+          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          echo "Looking for Docker Build run for commit: $COMMIT_SHA"
+
+          # Find the Docker Build workflow run for this commit
+          BUILD_RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/docker-build.yml/runs" \
+            --jq ".workflow_runs[] | select(.head_sha == \"$COMMIT_SHA\") | .id" \
+            | head -1)
+
+          if [ -z "$BUILD_RUN_ID" ]; then
+            echo "❌ Could not find Docker Build run for commit $COMMIT_SHA"
+            exit 1
+          fi
+
+          echo "✅ Found Docker Build run ID: $BUILD_RUN_ID"
+          echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
+
       - name: Download image artifact
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v4
@@ -80,7 +104,7 @@ jobs:
           name: docker-image
           path: /tmp/
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.find-build-run.outputs.build-run-id }}
 
       - name: Load and retag Docker image
         if: github.event_name == 'workflow_run'

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -49,6 +49,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Find Docker Build workflow run
+        if: github.event_name == 'workflow_run'
+        id: find-build-run
+        run: |
+          echo "🔍 Finding Docker Build workflow run for this commit..."
+
+          # Get the commit SHA from the triggering workflow
+          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          echo "Looking for Docker Build run for commit: $COMMIT_SHA"
+
+          # Find the Docker Build workflow run for this commit
+          BUILD_RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/docker-build.yml/runs" \
+            --jq ".workflow_runs[] | select(.head_sha == \"$COMMIT_SHA\") | .id" \
+            | head -1)
+
+          if [ -z "$BUILD_RUN_ID" ]; then
+            echo "❌ Could not find Docker Build run for commit $COMMIT_SHA"
+            exit 1
+          fi
+
+          echo "✅ Found Docker Build run ID: $BUILD_RUN_ID"
+          echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
+
       - name: Download image artifact
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v4
@@ -56,7 +80,7 @@ jobs:
           name: docker-image
           path: /tmp/
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.find-build-run.outputs.build-run-id }}
 
       - name: Load Docker image
         if: github.event_name == 'workflow_run'


### PR DESCRIPTION
- Use GitHub API in both Docker Test and Docker Publish to find original Docker Build run
- Ensures both workflows download artifacts from the same Docker Build run ID
- Fixes 'Artifact not found' errors throughout the workflow chain
- Maintains consistency: both Test and Publish get identical Docker images
- Industry standard approach using workflow run APIs for artifact resolution
- Eliminates run ID confusion between workflow_run events