### PR TITLE
ci: fix Docker artifact chain with simplified workflow run ID logic

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,30 +73,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Find Docker Build workflow run
+      - name: Set Docker Build run ID
         if: github.event_name == 'workflow_run'
         id: find-build-run
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🔍 Finding Docker Build workflow run for this commit..."
-
-          # Get the commit SHA from the triggering workflow
-          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
-          echo "Looking for Docker Build run for commit: $COMMIT_SHA"
-
-          # Find the Docker Build workflow run for this commit
-          BUILD_RUN_ID=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/docker-build.yml/runs" \
-            --jq ".workflow_runs[] | select(.head_sha == \"$COMMIT_SHA\") | .id" \
-            | head -1)
-
-          if [ -z "$BUILD_RUN_ID" ]; then
-            echo "❌ Could not find Docker Build run for commit $COMMIT_SHA"
-            exit 1
-          fi
-
-          echo "✅ Found Docker Build run ID: $BUILD_RUN_ID"
+          echo "🔍 Using triggering Docker Build workflow run..."
+          
+          # The triggering workflow run IS the Docker Build run we need
+          BUILD_RUN_ID="${{ github.event.workflow_run.id }}"
+          echo "✅ Using Docker Build run ID: $BUILD_RUN_ID"
           echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Download image artifact

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -49,30 +49,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Find Docker Build workflow run
+      - name: Set Docker Build run ID
         if: github.event_name == 'workflow_run'
         id: find-build-run
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🔍 Finding Docker Build workflow run for this commit..."
-
-          # Get the commit SHA from the triggering workflow
-          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
-          echo "Looking for Docker Build run for commit: $COMMIT_SHA"
-
-          # Find the Docker Build workflow run for this commit
-          BUILD_RUN_ID=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/docker-build.yml/runs" \
-            --jq ".workflow_runs[] | select(.head_sha == \"$COMMIT_SHA\") | .id" \
-            | head -1)
-
-          if [ -z "$BUILD_RUN_ID" ]; then
-            echo "❌ Could not find Docker Build run for commit $COMMIT_SHA"
-            exit 1
-          fi
-
-          echo "✅ Found Docker Build run ID: $BUILD_RUN_ID"
+          echo "🔍 Using triggering Docker Build workflow run..."
+          
+          # The triggering workflow run IS the Docker Build run we need
+          BUILD_RUN_ID="${{ github.event.workflow_run.id }}"
+          echo "✅ Using Docker Build run ID: $BUILD_RUN_ID"
           echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Download image artifact


### PR DESCRIPTION
## 🔧 Problem
Docker Test and Publish workflows were failing with "Artifact not found" errors because they were using complex GitHub API logic to find Docker Build run IDs, which was unreliable due to commit SHA mismatches.

## 🛠️ Solution
Simplified the approach by using `github.event.workflow_run.id` directly instead of searching for it via API calls.

**Before:**
- Complex GitHub API search by commit SHA
- Required authentication and error handling
- Failed when commit SHAs didn't match expectations
- 30+ lines of code per workflow

**After:**
- Direct use of triggering workflow run ID
- No API calls or authentication needed  
- Always gets the correct artifact source
- 5 lines of code per workflow

## ✅ Benefits
- ✅ **More reliable**: No commit SHA matching issues
- ✅ **Simpler logic**: Eliminates complex API searches
- ✅ **Better performance**: No GitHub CLI dependency
- ✅ **Easier to maintain**: Much less code to debug

## 🧪 Testing
This addresses the root cause of the Docker workflow chain failures we've been seeing.

## 📁 Files Changed
- `.github/workflows/docker-test.yml`: Simplified artifact download logic
- `.github/workflows/docker-publish.yml`: Simplified artifact download logic

Fixes the Docker workflow artifact chain issues.