### PR TITLE
ci: fix Docker Publish artifact chain - use correct Build run ID

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,15 +73,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set Docker Build run ID
+      - name: Find Docker Build run ID
         if: github.event_name == 'workflow_run'
         id: find-build-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🔍 Using triggering Docker Build workflow run..."
+          echo "🔍 Finding Docker Build run for the original commit..."
           
-          # The triggering workflow run IS the Docker Build run we need
-          BUILD_RUN_ID="${{ github.event.workflow_run.id }}"
-          echo "✅ Using Docker Build run ID: $BUILD_RUN_ID"
+          # Use the commit SHA from the original push event
+          COMMIT_SHA="${{ github.sha }}"
+          echo "Looking for Docker Build run for commit: $COMMIT_SHA"
+          
+          # Find the Docker Build workflow run for this commit
+          BUILD_RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/docker-build.yml/runs" \
+            --jq ".workflow_runs[] | select(.head_sha == \"$COMMIT_SHA\") | .id" \
+            | head -1)
+          
+          if [ -z "$BUILD_RUN_ID" ]; then
+            echo "❌ Could not find Docker Build run for commit $COMMIT_SHA"
+            exit 1
+          fi
+          
+          echo "✅ Found Docker Build run ID: $BUILD_RUN_ID"
           echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Download image artifact

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           echo "🔍 Using triggering Docker Build workflow run..."
           
-          # The triggering workflow run IS the Docker Build run we need
+          # For Docker Test, the triggering workflow IS the Docker Build run
           BUILD_RUN_ID="${{ github.event.workflow_run.id }}"
           echo "✅ Using Docker Build run ID: $BUILD_RUN_ID"
           echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🔧 Critical Issue Discovered

After merging PR #55, we discovered that Docker Publish was still failing because it was getting the **Docker Test run ID** instead of the **Docker Build run ID**.

## 🔍 Root Cause

**Workflow Chain:**
1. **Docker Build** → creates artifact ✅  
2. **Docker Test** → triggered by Build → downloads artifact ✅
3. **Docker Publish** → triggered by Test → was trying to download from Test ❌

**Problem:**
When Docker Publish used `github.event.workflow_run.id`, it got the **triggering workflow ID** (Docker Test), but the artifact is in the **Docker Build workflow**.

## 🛠️ Solution

- **Docker Test**: Still uses `workflow_run.id` (correctly triggered by Build) ✅
- **Docker Publish**: Now uses `github.sha` + API to find the **correct Docker Build run** ✅

**Key Changes:**
- Docker Publish now searches for Docker Build run using the original commit SHA
- Uses GitHub API with authentication to find the correct artifact source
- Maintains proper workflow chain: Build → Test → Publish

## 🎯 Impact

This fixes the "Artifact not found" errors in Docker Publish by ensuring it downloads artifacts from the correct Docker Build workflow.

## 📁 Files Changed
- `.github/workflows/docker-publish.yml`: Updated to find correct Build run ID
- `.github/workflows/docker-test.yml`: Added clarifying comments

Related to PR #55 - this is the follow-up fix for the artifact chain issue.