### PR TITLE
ci: standardize GitHub workflows structure and formatting

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,7 @@ on:
         'fix/*',
         'hotfix/*',
         'release/*',
+        'ci/*',
       ]
     tags: ['v*']
   pull_request:
@@ -32,20 +33,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: docker-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: read
       packages: write
-    # Skip Docker builds for non-functional commits (docs, chore, test, ci, style)
-    # Skip version bump commits to avoid duplicate builds (tag push will build)
-    # But ALWAYS build for tag pushes (releases) regardless of commit message
-    if: ${{ github.event_name != 'push' ||
-      startsWith(github.ref, 'refs/tags/') ||
-      (!startsWith(github.event.head_commit.message, 'docs:') &&
-      !startsWith(github.event.head_commit.message, 'chore:') &&
-      !startsWith(github.event.head_commit.message, 'test:') &&
-      !startsWith(github.event.head_commit.message, 'ci:') &&
-      !startsWith(github.event.head_commit.message, 'style:') &&
-      !contains(github.event.head_commit.message, 'bump version to v')) }}
+      id-token: write
+      attestations: write
+    # Always build on branch pushes and tags to ensure images are available for testing
 
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
@@ -77,15 +73,20 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=sha
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
+            type=raw,value=latest,enable=${{ github.event_name != 'pull_request' && github.ref_name == 'main' }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
+      - name: Build Docker image (PR validation)
+        if: github.event_name == 'pull_request'
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -104,15 +105,33 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 
-      - name: Basic image validation
+      - name: Build and push Docker image (multi-arch)
+        if: github.event_name != 'pull_request'
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=build
+            type=gha,scope=build-${{ github.ref_name }}
+          cache-to: |
+            type=gha,mode=max,scope=build
+            type=gha,mode=max,scope=build-${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Basic image validation (PRs)
+        if: github.event_name == 'pull_request'
         run: |
           echo "🔍 Running basic Docker image validation..."
 
-          # Get the first tag (usually the PR or branch tag)
           TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
           echo "Validating image: $TAG"
 
-          # Basic image structure validation
           if docker run --rm --entrypoint="" $TAG node --version; then
             echo "✅ Node.js runtime available"
           else
@@ -120,7 +139,6 @@ jobs:
             exit 1
           fi
 
-          # Verify main entry point exists
           if docker run --rm --entrypoint="" $TAG ls src/main.js >/dev/null 2>&1; then
             echo "✅ Main entry point exists"
           else
@@ -130,20 +148,34 @@ jobs:
 
           echo "✅ Basic image validation passed"
 
-      - name: Export image for testing
+      - name: Verify published images (non-PR)
         if: github.event_name != 'pull_request'
         run: |
-          # Get the first tag for export
-          TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
-          echo "Exporting image: $TAG"
+          echo "🔍 Verifying published Docker images..."
 
-          # Save image as tar for use in subsequent workflows
-          docker save $TAG > /tmp/docker-image.tar
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              echo "Verifying published image: $tag"
+              if docker pull $tag >/dev/null 2>&1; then
+                echo "✅ Successfully verified: $tag"
+              else
+                echo "❌ CRITICAL FAILURE: Could not pull published image: $tag"
+                exit 1
+              fi
 
-      - name: Upload image artifact
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+              if docker run --rm --entrypoint="" $tag node --version >/dev/null 2>&1; then
+                echo "✅ Smoke test passed for: $tag"
+              else
+                echo "❌ CRITICAL FAILURE: Smoke test failed for: $tag"
+                exit 1
+              fi
+            fi
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+      - name: Generate image attestation
+        if: github.event_name != 'pull_request' && (github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/'))
+        uses: actions/attest-build-provenance@v1
         with:
-          name: docker-image
-          path: /tmp/docker-image.tar
-          retention-days: 1
+          subject-name: ${{ env.REGISTRY }}/${{ steps.repo_name.outputs.lowercase }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ jobs:
     # Always build on branch pushes and tags to ensure images are available for testing
 
     outputs:
-      image-digest: ${{ steps.build.outputs.digest }}
+      image-digest: ${{ steps.build.outputs.digest || steps.build-push.outputs.digest }}
       image-tags: ${{ steps.meta.outputs.tags }}
       image-labels: ${{ steps.meta.outputs.labels }}
 
@@ -107,7 +107,7 @@ jobs:
 
       - name: Build and push Docker image (multi-arch)
         if: github.event_name != 'pull_request'
-        id: build
+        id: build-push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -177,5 +177,5 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ steps.repo_name.outputs.lowercase }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,31 +1,12 @@
-name: Docker Publish
+name: Docker Publish (Deprecated)
 
 on:
-  workflow_run:
-    workflows: ['Docker Test']
-    types:
-      - completed
-    branches:
-      [
-        main,
-        'feature/*',
-        'feat/*',
-        'bugfix/*',
-        'fix/*',
-        'hotfix/*',
-        'release/*',
-        'ci/*',
-      ]
-  workflow_call:
+  workflow_dispatch:
     inputs:
-      image-tags:
-        description: 'Docker image tags to publish'
+      reason:
+        description: 'Reason for manual publish (deprecated)'
         required: true
-        type: string
-      image-labels:
-        description: 'Docker image labels'
-        required: true
-        type: string
+        default: 'Use docker-build.yml which now handles publish'
 
 env:
   REGISTRY: ghcr.io
@@ -40,8 +21,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    # Only run if the Docker Test workflow succeeded (workflow_run events don't include PRs)
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_call' }}
+    if: false # Fully disabled; superseded by docker-build.yml
 
     steps:
       - name: Checkout repository
@@ -132,6 +112,7 @@ jobs:
       # For PRs, we already built the image in docker-build, so we can build and push directly
       - name: Build and push Docker image (multi-platform)
         id: publish
+        if: false
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -3,8 +3,7 @@ name: Docker Test
 on:
   workflow_run:
     workflows: ['Docker Build']
-    types:
-      - completed
+    types: [completed]
     branches:
       [
         main,
@@ -36,7 +35,7 @@ jobs:
       contents: read
       packages: read
     # Only run if the Docker Build workflow succeeded, or this is a PR, or workflow_call
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_call' || github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_call' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
 
     steps:
       - name: Checkout repository
@@ -49,36 +48,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set Docker Build run ID
+      - name: Determine image tag to test (workflow_run)
         if: github.event_name == 'workflow_run'
-        id: find-build-run
+        id: set-image-tag
         run: |
-          echo "🔍 Using triggering Docker Build workflow run..."
-          
-          # For Docker Test, the triggering workflow IS the Docker Build run
-          BUILD_RUN_ID="${{ github.event.workflow_run.id }}"
-          echo "✅ Using Docker Build run ID: $BUILD_RUN_ID"
-          echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
+          echo "🔍 Determining image tag to test from workflow_run..."
 
-      - name: Download image artifact
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
-        with:
-          name: docker-image
-          path: /tmp/
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ steps.find-build-run.outputs.build-run-id }}
+          # Lowercase repository for GHCR compatibility
+          LOWER_REPO=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
 
-      - name: Load Docker image
-        if: github.event_name == 'workflow_run'
-        run: |
-          echo "Loading Docker image from artifact..."
-          docker load < /tmp/docker-image.tar
+          # Use the head SHA from the triggering build (short 7 chars)
+          SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
 
-          # Get the loaded image tag
-          TAG=$(docker images --format "table {{.Repository}}:{{.Tag}}" | grep -E "ghcr.io.*shelfbridge" | head -n1)
-          echo "Loaded image: $TAG"
-          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+          IMAGE_TAG="ghcr.io/${LOWER_REPO}:sha-${SHORT_SHA}"
+          echo "Testing image: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
 
       - name: Build image for PR testing
         if: github.event_name == 'pull_request'

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -37,32 +37,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.RELEASE_TOKEN || github.token }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.19.4'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Wait for Docker publish to complete
-        uses: lewagon/wait-on-check-action@v1.4.0
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-          check-name: 'publish'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          allowed-conclusions: success,skipped
-
       - name: Success message
         run: |
           echo "✅ Release ${{ needs.release-please.outputs.tag_name }} created successfully"
           echo "🏷️ Tag ${{ needs.release-please.outputs.tag_name }} pushed"
-          echo "🐳 Docker images built and pushed successfully"
+          echo "🐳 Docker images will be built and pushed by the 'Docker Build' workflow"
           echo "📦 Release available at: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}"
-          echo "🚀 All Docker images are ready for immediate use"
+          echo "🚀 Multi-arch Docker images will be available shortly after the workflow completes"

--- a/wiki/technical/GitHub-Workflows.md
+++ b/wiki/technical/GitHub-Workflows.md
@@ -509,6 +509,15 @@ Docker builds are optimized to only run when necessary:
 - Pull requests (for testing)
 - Any commits not starting with excluded prefixes
 
+### Build Step Reliability
+
+**Fixed Issue:** Resolved YAML syntax error that was preventing the Docker Build workflow from executing:
+
+- ✅ **Duplicate ID fix** - Fixed duplicate `id: build` that caused workflow parsing errors
+- ✅ **Proper step isolation** - PR builds use `id: build`, push builds use `id: build-push`
+- ✅ **Output handling** - Dynamic output references handle both PR and push scenarios
+- ✅ **Status check reliability** - Workflow now properly reports "Docker Build / build" status
+
 ### Version-Specific Docker Images
 
 **Fixed Issue:** The workflow now ensures that version-specific Docker images are created for every release:


### PR DESCRIPTION
- Consolidate Docker build and publish workflows for better reliability
- Deprecate docker-publish.yml in favor of unified docker-build.yml approach
- Add ci/* branch support to trigger patterns for workflow testing
- Standardize permissions and timeout configurations across all workflows
- Update workflow documentation to reflect consolidation changes