### PR TITLE
ci: fix Release Please workflow permissions error

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -31,6 +31,12 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/docker-build.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    secrets: inherit
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}
       is_release: true

--- a/wiki/technical/GitHub-Workflows.md
+++ b/wiki/technical/GitHub-Workflows.md
@@ -392,7 +392,7 @@ The workflow now ensures that version-specific Docker images are automatically c
 **How It Works:**
 
 1. Release Please creates release and pushes tag
-2. Version workflow directly calls Docker build workflow via `workflow_call`
+2. Version workflow directly calls Docker build workflow via `workflow_call` with `secrets: inherit`
 3. Docker build completes with all image tags before release notification
 4. Release notification includes actual built image tags for immediate use
 


### PR DESCRIPTION
## 🚨 Hotfix: Release Please Workflow Failure

**Issue:** Release Please workflow failing with permissions error:
```
Error calling workflow 'rohit-purandare/ShelfBridge/.github/workflows/docker-build.yml'. 
The nested job 'build' is requesting 'attestations: write, packages: write, id-token: write', 
but is only allowed 'attestations: none, packages: read, id-token: none'.
```

## 🔧 Root Cause

When calling a reusable workflow (`docker-build.yml`) from `version-and-release.yml`, the called workflow needs proper permissions to:
- Write to GitHub Container Registry (`packages: write`)
- Create attestations (`attestations: write`) 
- Use OIDC tokens (`id-token: write`)

## ✅ Solution

Added required permissions and `secrets: inherit` to the reusable workflow call:

```yaml
build-and-publish:
  uses: ./.github/workflows/docker-build.yml
  permissions:
    contents: read
    packages: write
    id-token: write
    attestations: write
  secrets: inherit
  with:
    ref: ${{ needs.release-please.outputs.tag_name }}
    is_release: true
```

## 🎯 Impact

- ✅ **Fixes Release Please workflow** - can now successfully create releases
- ✅ **Enables Docker publishing** - releases will build and publish Docker images
- ✅ **Maintains security** - only grants necessary permissions for reusable workflow
- ✅ **Preserves functionality** - no changes to release behavior, just fixes permissions

## 📚 Documentation

Updated `wiki/technical/GitHub-Workflows.md` to document the `secrets: inherit` requirement for reusable workflow calls.

## ⚡ Priority

**HIGH** - Blocks all releases until merged. This is a critical hotfix for release functionality.