### PR TITLE
ci: hide dependency updates from release changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,12 @@
           "section": "## ⚡ Performance Improvements",
           "hidden": false
         },
-        { "type": "deps", "section": "## 📦 Dependencies", "hidden": false },
+        { "type": "deps", "section": "## 📦 Dependencies", "hidden": true },
+        {
+          "type": "build(deps)",
+          "section": "## 📦 Dependencies",
+          "hidden": true
+        },
         { "type": "revert", "section": "## ⏪ Reverts", "hidden": false },
         {
           "type": "refactor",


### PR DESCRIPTION
- Add build(deps) type to hidden changelog sections
- Set deps type to hidden to prevent routine dependency updates from triggering releases
- This ensures only functional changes (feat/fix) create releases while dependency maintenance stays in background