### PR TITLE
ci: fix release-please tag component detection for single-package repo

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -62,7 +62,8 @@
           "bump": false
         }
       ],
-      "extra-files": ["package.json", "package-lock.json"]
+      "extra-files": ["package.json", "package-lock.json"],
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
- Add include-component-in-tag: false to handle simple v1.19.x tag format
- Resolves 'Found release tag with component '', but not configured in manifest' warnings
- Allows Release Please to properly detect existing releases without component prefixes
- Should fix Release Please scanning 239 commits instead of recent ones