### PR TITLE
ci: fix Docker builds not triggering after release-please PRs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,8 +29,9 @@ on:
         'staging/*', # Staging branches
         'patch/*', # Patch branches
       ]
-    # Remove tags trigger to avoid duplicate builds during releases
-    # Tags will be handled via workflow_call from version-and-release.yml
+    # Fallback: Also trigger on version tags in case workflow_call fails
+    tags:
+      - 'v*'
     paths:
       - 'Dockerfile'
       - 'docker-*.sh'
@@ -90,10 +91,11 @@ jobs:
       id-token: write
       attestations: write
     # Skip build for Release Please commits on main (handled by version-and-release.yml)
-    # Always build for workflow_call, feature branches, and non-release commits
+    # Always build for workflow_call, feature branches, tag pushes, and non-release commits
     if: |
       github.event_name == 'workflow_call' || 
       github.event_name == 'pull_request' ||
+      startsWith(github.ref, 'refs/tags/') ||
       github.ref_name != 'main' ||
       !contains(github.event.head_commit.message, 'chore(main): release')
 

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -32,7 +32,7 @@ jobs:
   # Only run build and publish when a release is created
   build-and-publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created || needs.release-please.outputs.tag_name != '' }}
     uses: ./.github/workflows/docker-build.yml
     permissions:
       contents: read
@@ -48,7 +48,7 @@ jobs:
   notify-success:
     runs-on: ubuntu-latest
     needs: [release-please, build-and-publish]
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created || needs.release-please.outputs.tag_name != '' }}
     steps:
       - name: Release success message
         run: |


### PR DESCRIPTION
- Add fallback condition to check tag_name when release_created is false
- Add tag-based triggers to docker-build workflow as backup
- Ensure Docker images are built for all releases even when release-please action outputs release_created=false due to dual-phase execution
- Update GitHub-Workflows.md documentation with fix details

Related to #X