### PR TITLE
ci: fix Docker Build workflow to always report status for branch prot…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,17 +45,6 @@ on:
       - '!wiki/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'Dockerfile'
-      - 'docker-*.sh'
-      - 'src/**'
-      - 'package*.json'
-      - 'release-please-config.json'
-      - '.release-please-manifest.json'
-      - '.github/workflows/docker-*.yml'
-      - '!**.md'
-      - '!docs/**'
-      - '!wiki/**'
   workflow_call:
     inputs:
       ref:
@@ -111,6 +100,26 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           # Fetch tags for semver extraction when building releases
           fetch-depth: ${{ inputs.is_release && '0' || '1' }}
+
+      - name: Check if Docker build is needed
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docker:
+              - 'Dockerfile'
+              - 'docker-*.sh'
+              - 'src/**'
+              - 'package*.json'
+              - 'release-please-config.json'
+              - '.release-please-manifest.json'
+              - '.github/workflows/docker-*.yml'
+
+      - name: Skip message for docs-only changes
+        if: steps.changes.outputs.docker != 'true'
+        run: |
+          echo "⏭️ Skipping Docker build - no relevant files changed"
+          echo "This is expected for documentation-only changes"
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -168,7 +177,7 @@ jobs:
           sbom: false
 
       - name: Build and push Docker image (multi-arch)
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.changes.outputs.docker == 'true'
         id: build-push
         uses: docker/build-push-action@v6
         with:

--- a/wiki/technical/GitHub-Workflows.md
+++ b/wiki/technical/GitHub-Workflows.md
@@ -561,6 +561,26 @@ Docker builds are optimized to only run when necessary:
 - ✅ **Output handling** - Dynamic output references handle both PR and push scenarios
 - ✅ **Status check reliability** - Workflow now properly reports "Docker Build / build" status
 
+### Branch Protection Status Reporting (RESOLVED)
+
+**Fixed Issue:** Resolved "build" status check blocking PRs when Docker build was skipped for docs-only changes
+
+**Previous Problem:**
+
+- Branch protection required "build" status check for all PRs
+- Docker Build workflow used path filters that skipped docs-only changes (`.md` files)
+- PRs with only documentation changes got stuck waiting for "build" status that never reported
+
+**Solution Applied:** Always-run workflow with internal path detection
+
+- ✅ **Removed path filters** from `pull_request` trigger - workflow always runs for all PRs
+- ✅ **Added internal path detection** using `dorny/paths-filter@v3` action
+- ✅ **Smart build logic** - PRs always build Docker images for local testing
+- ✅ **Conditional push builds** - Push events only build when relevant files change
+- ✅ **Always reports status** - Workflow provides "build" status for branch protection regardless of file changes
+
+**Result:** Documentation-only PRs no longer get stuck, while maintaining Docker build requirements for code changes.
+
 ### Version-Specific Docker Images
 
 **Fixed Issue:** The workflow now ensures that version-specific Docker images are created for every release:


### PR DESCRIPTION
…ection

- Remove path filters from pull_request trigger so workflow always runs
- Add internal path detection using dorny/paths-filter@v3
- PRs always build Docker images for local testing (regardless of files changed)
- Push events only build when relevant files are modified (src/**, Dockerfile, etc.)
- Workflow always reports 'build' status for branch protection requirements
- Resolves issue where docs-only PRs were stuck waiting for build status

📚 Update GitHub Workflows wiki documentation with new status reporting fix