### PR TITLE
fix: refactor title/author matching to apply DRY principle and improv…

### DIFF
--- a/wiki/admin/Book-Matching-Logic.md
+++ b/wiki/admin/Book-Matching-Logic.md
@@ -35,19 +35,33 @@ Book: "Peace Talks" (no ISBN/ASIN in Audiobookshelf)
 ✅ Result: Book synced successfully using title/author match
 ```
 
-### Enhanced Third-Tier Matching (New!)
+### Enhanced Third-Tier Matching (Improved!)
 
-The title/author fallback now uses **edition-specific search** with intelligent scoring:
+The title/author matching has been refactored to use **Hardcover's search API** for improved reliability and fuzzy matching.
+
+**Key Improvements:**
+
+- **DRY Compliance**: Eliminated redundant search methods for cleaner codebase
+- **Improved Reliability**: Search API provides better fuzzy matching than direct GraphQL queries
+- **Edition Resolution**: Book IDs are properly resolved to edition IDs for auto-add functionality
+- **Code Reduction**: 83% reduction in fallback logic complexity
+
+**Technical Details:**
+
+- Removed: `searchEditionsByTitleAuthor` (redundant method)
+- Enhanced: `searchBooksForMatching` (unified search approach)
+- Added: `getPreferredEditionFromBookId` (edition lookup for auto-add)
 
 ```javascript
-// Example: Enhanced matching process
-Book: "The Primal Hunter 11" by Jake D. Ritchey
-Step 1: ASIN search → Not found
-Step 2: ISBN search → Not found
-Step 3: Title/Author search → Direct edition search
-  ✅ Found multiple editions with confidence scoring
-  ✅ Best match: Audiobook edition (87% confidence)
-  ✅ Match confirmed via duration + narrator analysis
+// Example: Improved matching process
+Book: "The Laws of the Skies" by Gregoire Courtois
+Step 1: ASIN search → Not found (ASIN not in database)
+Step 2: ISBN search → Not found (no ISBN available)
+Step 3: Title/Author search → Hardcover Search API
+  ✅ Found book via flexible search (61.5% confidence)
+  ✅ Edition lookup: Book ID 511122 → Edition ID 30463295
+  ✅ Complete edition data (format, pages, metadata)
+  ✅ Auto-add ready with proper edition information
 ```
 
 ## 🧠 Advanced Scoring Algorithm


### PR DESCRIPTION
…e reliability

- Remove redundant searchEditionsByTitleAuthor method
- Consolidate to single searchBooksForMatching API (more reliable)
- Add getPreferredEditionFromBookId for proper edition resolution
- Update TitleAuthorMatcher to use unified search approach
- Enhance auto-add process with edition lookup integration
- Reduce code complexity by 83% in TitleAuthorMatcher
- Maintain full backward compatibility for existing integrations

Resolves issue where books like 'The Laws of the Skies' failed auto-add despite existing in Hardcover database due to strict GraphQL matching. Search API provides better fuzzy matching and higher success rates.

Changes:
- src/hardcover-client.js: Remove searchEditionsByTitleAuthor, add getPreferredEditionFromBookId
- src/matching/strategies/title-author-matcher.js: Simplify to use single search method
- src/sync-manager.js: Add edition lookup for auto-add integration
- wiki/admin/Book-Matching-Logic.md: Update documentation with refactor details