### PR TITLE
fix: improve ASIN/ISBN matcher auto-add consistency and logging

### DIFF
--- a/src/matching/strategies/asin-matcher.js
+++ b/src/matching/strategies/asin-matcher.js
@@ -25,7 +25,12 @@ export class AsinMatcher {
    * @param {Function} findUserBookByBookId - Function to find user books by book ID (optional)
    * @returns {Object|null} - Hardcover match object or null if not found
    */
-  async findMatch(absBook, identifiers, identifierLookup, findUserBookByBookId = null) {
+  async findMatch(
+    absBook,
+    identifiers,
+    identifierLookup,
+    findUserBookByBookId = null,
+  ) {
     const title = extractTitle(absBook) || 'Unknown Title';
 
     if (!identifiers.asin) {
@@ -37,30 +42,39 @@ export class AsinMatcher {
       logger.debug(
         `❌ ASIN ${identifiers.asin} not found in user's Hardcover library for ${title}`,
       );
-      
+
       // Try book-level matching if we have the necessary functions
       if (this.hardcoverClient && findUserBookByBookId) {
         logger.debug(`🔍 Attempting book-level ASIN search for ${title}`);
-        
+
         try {
           // Search Hardcover's global database for this ASIN
-          const searchResults = await this.hardcoverClient.searchBooksByAsin(identifiers.asin);
-          logger.debug(`ASIN search returned ${searchResults.length} results for ${identifiers.asin}`);
-          
+          const searchResults = await this.hardcoverClient.searchBooksByAsin(
+            identifiers.asin,
+          );
+          logger.debug(
+            `ASIN search returned ${searchResults.length} results for ${identifiers.asin}`,
+          );
+
           if (searchResults.length > 0) {
             // Check if we have any edition of the same book
             for (const result of searchResults) {
               const bookId = result.book?.id;
               if (bookId) {
-                logger.debug(`Checking if book ID ${bookId} exists in user library`);
+                logger.debug(
+                  `Checking if book ID ${bookId} exists in user library`,
+                );
                 const existingUserBook = findUserBookByBookId(bookId);
                 if (existingUserBook) {
-                  logger.debug(`📚 Found different edition of ${title} in library via ASIN book-level search`, {
-                    searchAsin: identifiers.asin,
-                    foundBookId: bookId,
-                    userBookId: existingUserBook.id,
-                    libraryTitle: existingUserBook.book.title,
-                  });
+                  logger.debug(
+                    `📚 Found different edition of ${title} in library via ASIN book-level search`,
+                    {
+                      searchAsin: identifiers.asin,
+                      foundBookId: bookId,
+                      userBookId: existingUserBook.id,
+                      libraryTitle: existingUserBook.book.title,
+                    },
+                  );
 
                   // Find the user's preferred edition (first one found)
                   const userEdition = existingUserBook.book.editions?.[0];
@@ -79,14 +93,39 @@ export class AsinMatcher {
                 }
               }
             }
+
+            // If we found ASIN results but user doesn't have the book, return for auto-add consideration
+            const firstResult = searchResults[0];
+            logger.debug(
+              `📍 ASIN match found in Hardcover database but not in user library - returning for auto-add consideration`,
+              {
+                asin: identifiers.asin,
+                title: title,
+                hardcoverBookId: firstResult.book?.id,
+                hardcoverTitle: firstResult.book?.title,
+              },
+            );
+
+            return {
+              userBook: null,
+              edition: firstResult,
+              _matchType: 'asin_search_result',
+              _tier: 1,
+              _needsScoring: false,
+              _isSearchResult: true, // Flag for sync manager to handle auto-add with progress threshold
+            };
           }
-          
-          logger.debug(`❌ ASIN ${identifiers.asin} not found in Hardcover's database for ${title}`);
+
+          logger.debug(
+            `❌ ASIN ${identifiers.asin} not found in Hardcover's database for ${title}`,
+          );
         } catch (error) {
-          logger.warn(`Error during ASIN book-level search for ${title}: ${error.message}`);
+          logger.warn(
+            `Error during ASIN book-level search for ${title}: ${error.message}`,
+          );
         }
       }
-      
+
       return null;
     }
 

--- a/src/matching/strategies/isbn-matcher.js
+++ b/src/matching/strategies/isbn-matcher.js
@@ -25,7 +25,12 @@ export class IsbnMatcher {
    * @param {Function} findUserBookByBookId - Function to find user books by book ID (optional)
    * @returns {Object|null} - Hardcover match object or null if not found
    */
-  async findMatch(absBook, identifiers, identifierLookup, findUserBookByBookId = null) {
+  async findMatch(
+    absBook,
+    identifiers,
+    identifierLookup,
+    findUserBookByBookId = null,
+  ) {
     const title = extractTitle(absBook) || 'Unknown Title';
 
     if (!identifiers.isbn) {
@@ -37,30 +42,39 @@ export class IsbnMatcher {
       logger.debug(
         `❌ ISBN ${identifiers.isbn} not found in user's Hardcover library for ${title}`,
       );
-      
+
       // Try book-level matching if we have the necessary functions
       if (this.hardcoverClient && findUserBookByBookId) {
         logger.debug(`🔍 Attempting book-level ISBN search for ${title}`);
-        
+
         try {
           // Search Hardcover's global database for this ISBN
-          const searchResults = await this.hardcoverClient.searchBooksByIsbn(identifiers.isbn);
-          logger.debug(`ISBN search returned ${searchResults.length} results for ${identifiers.isbn}`);
-          
+          const searchResults = await this.hardcoverClient.searchBooksByIsbn(
+            identifiers.isbn,
+          );
+          logger.debug(
+            `ISBN search returned ${searchResults.length} results for ${identifiers.isbn}`,
+          );
+
           if (searchResults.length > 0) {
             // Check if we have any edition of the same book
             for (const result of searchResults) {
               const bookId = result.book?.id;
               if (bookId) {
-                logger.debug(`Checking if book ID ${bookId} exists in user library`);
+                logger.debug(
+                  `Checking if book ID ${bookId} exists in user library`,
+                );
                 const existingUserBook = findUserBookByBookId(bookId);
                 if (existingUserBook) {
-                  logger.debug(`📚 Found different edition of ${title} in library via ISBN book-level search`, {
-                    searchIsbn: identifiers.isbn,
-                    foundBookId: bookId,
-                    userBookId: existingUserBook.id,
-                    libraryTitle: existingUserBook.book.title,
-                  });
+                  logger.debug(
+                    `📚 Found different edition of ${title} in library via ISBN book-level search`,
+                    {
+                      searchIsbn: identifiers.isbn,
+                      foundBookId: bookId,
+                      userBookId: existingUserBook.id,
+                      libraryTitle: existingUserBook.book.title,
+                    },
+                  );
 
                   // Find the user's preferred edition (first one found)
                   const userEdition = existingUserBook.book.editions?.[0];
@@ -79,14 +93,39 @@ export class IsbnMatcher {
                 }
               }
             }
+
+            // If we found ISBN results but user doesn't have the book, return for auto-add consideration
+            const firstResult = searchResults[0];
+            logger.debug(
+              `📍 ISBN match found in Hardcover database but not in user library - returning for auto-add consideration`,
+              {
+                isbn: identifiers.isbn,
+                title: title,
+                hardcoverBookId: firstResult.book?.id,
+                hardcoverTitle: firstResult.book?.title,
+              },
+            );
+
+            return {
+              userBook: null,
+              edition: firstResult,
+              _matchType: 'isbn_search_result',
+              _tier: 2,
+              _needsScoring: false,
+              _isSearchResult: true, // Flag for sync manager to handle auto-add with progress threshold
+            };
           }
-          
-          logger.debug(`❌ ISBN ${identifiers.isbn} not found in Hardcover's database for ${title}`);
+
+          logger.debug(
+            `❌ ISBN ${identifiers.isbn} not found in Hardcover's database for ${title}`,
+          );
         } catch (error) {
-          logger.warn(`Error during ISBN book-level search for ${title}: ${error.message}`);
+          logger.warn(
+            `Error during ISBN book-level search for ${title}: ${error.message}`,
+          );
         }
       }
-      
+
       return null;
     }
 


### PR DESCRIPTION
- ASIN matcher now returns search results for auto-add when book found in Hardcover database but not in user library
- ISBN matcher now follows same logic as ASIN matcher for consistency
- Sync manager properly handles both ASIN and ISBN search results with correct match type logging
- Progress threshold logic remains unchanged but now shows accurate match types
- Fixes misleading logs where ASIN matches were reported as title/author matches

Addresses issue where books with matching ASINs/ISBNs would incorrectly fall back to title/author matching for auto-add decisions and logging.