### PR TITLE
ci: fix release-please workflow bad credentials error

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
+      repository-projects: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -26,7 +28,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+          token: ${{ github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/wiki/technical/GitHub-Workflows.md
+++ b/wiki/technical/GitHub-Workflows.md
@@ -227,6 +227,17 @@ node-version: [20.x, 22.x] # Supports current LTS (20) and latest stable (22)
 - **Action:** Creates Git tag and GitHub release automatically
 - **Integration:** Triggers Docker builds with versioned tags
 
+#### **🔧 Credentials Fix (Recently Fixed)**
+
+**Fixed Issue:** Release Please workflow failing with "Bad credentials" error
+
+- **Root Cause**: Workflow was trying to use `RELEASE_TOKEN` secret with insufficient permissions
+- **Solution**:
+  - Simplified to use default `github.token` which has proper repo context
+  - Added missing permissions: `issues: write` and `repository-projects: write`
+  - Removed dependency on custom `RELEASE_TOKEN` secret
+- **Result**: Release automation now works reliably with built-in GitHub token permissions
+
 #### **🐳 Docker Integration (Fixed)**
 
 - **Branch Testing:** Each branch push creates tagged images (e.g., `feature-auth`, `fix-bug-123`)


### PR DESCRIPTION
- Add missing permissions: issues:write and repository-projects:write
- Simplify token usage to use github.token directly instead of RELEASE_TOKEN fallback
- Resolves 'Bad credentials' error that was preventing release automation
- Update GitHub Workflows documentation with credentials fix details