### PR TITLE
ci: fix Docker test workflow for PR builds

### DIFF
--- a/.github/workflows/reusable-docker-validation.yml
+++ b/.github/workflows/reusable-docker-validation.yml
@@ -68,6 +68,17 @@ jobs:
           fi
           echo "✅ Image pulled successfully"
 
+      - name: Build Docker image locally
+        if: inputs.skip-pull == true
+        run: |
+          echo "🔨 Building Docker image locally for testing: ${{ inputs.image-tag }}"
+          echo "This is a PR build - image was not pushed to registry"
+          if ! docker build -t "${{ inputs.image-tag }}" .; then
+            echo "❌ Failed to build image locally: ${{ inputs.image-tag }}"
+            exit 1
+          fi
+          echo "✅ Image built successfully: ${{ inputs.image-tag }}"
+
       - name: Test Docker image native modules
         run: |
           echo "🧪 CRITICAL: Testing Docker image native modules compatibility..."

--- a/wiki/technical/GitHub-Workflows.md
+++ b/wiki/technical/GitHub-Workflows.md
@@ -872,7 +872,8 @@ This ensures that `latest` always points to the most recent stable build from th
 3. **Pull Request Support** 🔧 _Recently Fixed_
    - **Smart Event Detection**: Uses `github.event.workflow_run.event` to properly detect PR vs branch builds
    - **Correct PR Tag Resolution**: Extracts PR numbers from `pull_requests[0].number` with fallback handling
-   - **Local Image Building**: Rebuilds PR images locally since they're not pushed to registry
+   - **Local Image Building**: Added missing build step in reusable validation workflow when `skip-pull=true`
+   - **Fixed Issue**: Resolved "manifest unknown" error where PR tests failed because images weren't built locally
    - **Comprehensive Testing**: Ensures PR changes don't break container functionality before merge
 
 ### Testing Strategy


### PR DESCRIPTION
- Add missing local build step when skip-pull=true in reusable-docker-validation.yml
- Previously workflow would skip pull but had no logic to build image locally for PR testing
- Resolves 'manifest unknown' error when testing PR Docker images
- Ensures PR builds are properly tested before merge
- Update GitHub Workflows documentation with PR build fix details