### PR TITLE
fix: use correct semver tag configuration with value parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,13 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/shelfbridge
           tags: |
-            # Version tags
-            type=semver,pattern=v{{version}}
-            type=semver,pattern={{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=semver,pattern={{major}}
+            # Version tags using release-please outputs
+            type=semver,pattern=v{{version}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern=v{{major}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{major}},value=${{ needs.release-please.outputs.tag_name }}
             # Latest tag
             type=raw,value=latest
           flavor: |

--- a/wiki/technical/GitHub-Workflows.md
+++ b/wiki/technical/GitHub-Workflows.md
@@ -98,15 +98,19 @@ ShelfBridge uses **3 streamlined GitHub Actions workflows** following industry s
 
 #### 3. **Docker Tags Created**
 
+The Docker metadata action now properly generates semantic version tags by overriding the GitHub context with the actual tag reference:
+
 ```
 ghcr.io/rohit-purandare/shelfbridge:latest
-ghcr.io/rohit-purandare/shelfbridge:v1.21.0
-ghcr.io/rohit-purandare/shelfbridge:1.21.0
-ghcr.io/rohit-purandare/shelfbridge:v1.21
-ghcr.io/rohit-purandare/shelfbridge:1.21
+ghcr.io/rohit-purandare/shelfbridge:v1.22.0
+ghcr.io/rohit-purandare/shelfbridge:1.22.0
+ghcr.io/rohit-purandare/shelfbridge:v1.22
+ghcr.io/rohit-purandare/shelfbridge:1.22
 ghcr.io/rohit-purandare/shelfbridge:v1
 ghcr.io/rohit-purandare/shelfbridge:1
 ```
+
+**Technical Implementation:** The workflow uses the `value` parameter in semver tag patterns to explicitly provide the version from release-please outputs (`needs.release-please.outputs.tag_name`), ensuring proper semver tags are generated even when triggered by a push to main instead of a tag push.
 
 #### 4. **Image Verification**
 


### PR DESCRIPTION
- Configure Docker metadata action to use release-please outputs for proper semver tag generation
- Add value parameter to semver tag patterns to override GitHub context with actual tag reference
- Update documentation to reflect technical implementation details

This ensures Docker images get proper semantic version tags when workflow is triggered by push to main rather than tag push.