### PR TITLE
fix: count completed ABS media progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cron": "^3.5.0",
         "cronstrue": "^3.2.0",
         "inquirer": "^12.9.4",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "5.0.0",
         "luxon": "^3.7.1",
         "node-cron": "^4.2.1",
         "p-queue": "^8.1.0",
@@ -1626,16 +1626,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1792,9 +1792,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2032,15 +2032,25 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.0.0.tgz",
+      "integrity": "sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "interactive": "node src/main.js interactive",
     "cron": "node src/main.js cron",
     "sync": "node src/main.js sync",
-    "test": "node --test tests/network-utilities.test.js tests/progress-manager.test.js tests/task-queue-basic.test.js tests/transaction.test.js tests/utilities.test.js",
+    "test": "node --test tests/network-utilities.test.js tests/progress-manager.test.js tests/retry-manager.test.js tests/task-queue-basic.test.js tests/transaction.test.js tests/utilities.test.js",
     "test:connections": "node src/main.js test",
     "test:native": "node scripts/test-native-modules.js",
     "validate:sqlite": "node scripts/validate-better-sqlite3.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cron": "^3.5.0",
     "cronstrue": "^3.2.0",
     "inquirer": "^12.9.4",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "5.0.0",
     "luxon": "^3.7.1",
     "node-cron": "^4.2.1",
     "p-queue": "^8.1.0",
@@ -83,6 +83,8 @@
     "string-width": "7.2.0",
     "wrap-ansi": "9.0.0",
     "color-convert": "2.0.1",
-    "simple-swizzle": "0.2.2"
+    "simple-swizzle": "0.2.2",
+    "form-data": "4.0.6",
+    "js-yaml": "5.0.0"
   }
 }

--- a/src/audiobookshelf-client.js
+++ b/src/audiobookshelf-client.js
@@ -89,6 +89,11 @@ export class AudiobookshelfClient {
    * Clean up HTTP connections and resources
    */
   cleanup() {
+    if (this.rateLimiter) {
+      this.rateLimiter.destroy();
+      logger.debug('AudiobookshelfClient rate limiter cleaned up');
+    }
+
     if (this._httpAgent) {
       this._httpAgent.destroy();
       logger.debug('AudiobookshelfClient HTTP agent cleaned up');
@@ -254,54 +259,72 @@ export class AudiobookshelfClient {
         librariesSkipped: libraryFilter.stats.excluded,
       });
 
-      // Get library items in progress (these have some progress) - filtered by allowed libraries
-      const progressItems = await this._getItemsInProgress(librariesToProcess);
-      logger.debug('Found items in progress', { count: progressItems.length });
+      let progressResults;
 
-      // Always check for completed books to ensure completion detection on every sync
-      logger.debug('Checking for completed books across filtered libraries');
-      const completedBooksList =
-        await this._getCompletedBooksFromLibraries(librariesToProcess);
-      logger.debug('Found books with completion status', {
-        count: completedBooksList.length,
-      });
+      if (Array.isArray(userData.mediaProgress)) {
+        logger.debug('Using mediaProgress from /api/me as progress source', {
+          count: userData.mediaProgress.length,
+        });
+        progressResults = await this._getProgressBooksFromMediaProgress(
+          userData.mediaProgress,
+          librariesToProcess,
+        );
+      } else {
+        // Get library items in progress (these have some progress) - filtered by allowed libraries
+        const progressItems =
+          await this._getItemsInProgress(librariesToProcess);
+        logger.debug('Found items in progress', {
+          count: progressItems.length,
+        });
 
-      // Combine progress items with completed books (avoiding duplicates)
-      const allBooksWithAnyProgress = this._combineProgressAndCompletedBooks(
-        progressItems,
-        completedBooksList,
-      );
-      logger.debug('Total books with any progress (in-progress + completed)', {
-        count: allBooksWithAnyProgress.length,
-      });
+        // Always check for completed books to ensure completion detection on every sync
+        logger.debug('Checking for completed books across filtered libraries');
+        const completedBooksList =
+          await this._getCompletedBooksFromLibraries(librariesToProcess);
+        logger.debug('Found books with completion status', {
+          count: completedBooksList.length,
+        });
+
+        // Combine progress items with completed books (avoiding duplicates)
+        const allBooksWithAnyProgress = this._combineProgressAndCompletedBooks(
+          progressItems,
+          completedBooksList,
+        );
+        logger.debug(
+          'Total books with any progress (in-progress + completed)',
+          {
+            count: allBooksWithAnyProgress.length,
+          },
+        );
+
+        // Fetch details for ALL books with any progress (in-progress + completed) in parallel
+        const allProgressPromises = allBooksWithAnyProgress.map(item =>
+          this._getLibraryItemDetails(item.id).catch(error => {
+            // Only catch recoverable errors, let critical ones propagate
+            if (this._isRecoverableError(error)) {
+              logger.debug('Recoverable error fetching details for item', {
+                itemId: item.id,
+                error: error.message,
+              });
+              return null;
+            } else {
+              logger.error('Critical error fetching details for item', {
+                itemId: item.id,
+                error: error.message,
+              });
+              throw error; // Re-throw critical errors
+            }
+          }),
+        );
+
+        progressResults = await Promise.all(allProgressPromises);
+      }
 
       // Only process books that actually have reading progress
       const booksToSync = [];
 
-      // Fetch details for ALL books with any progress (in-progress + completed) in parallel
-      const allProgressPromises = allBooksWithAnyProgress.map(item =>
-        this._getLibraryItemDetails(item.id).catch(error => {
-          // Only catch recoverable errors, let critical ones propagate
-          if (this._isRecoverableError(error)) {
-            logger.debug('Recoverable error fetching details for item', {
-              itemId: item.id,
-              error: error.message,
-            });
-            return null;
-          } else {
-            logger.error('Critical error fetching details for item', {
-              itemId: item.id,
-              error: error.message,
-            });
-            throw error; // Re-throw critical errors
-          }
-        }),
-      );
-
-      const progressResults = await Promise.all(allProgressPromises);
-
-      // Debug: Show all books found in progress
-      logger.debug('Books found in items-in-progress API:', {
+      // Debug: Show all books found with progress
+      logger.debug('Books found with media progress:', {
         books: progressResults.filter(Boolean).map(book => {
           const title =
             (book &&
@@ -362,7 +385,10 @@ export class AudiobookshelfClient {
         return !isFinished; // Books that are currently being read
       });
 
-      const booksNeverStarted = totalBooksInLibrary - validBooks.length;
+      const booksNeverStarted = Math.max(
+        0,
+        totalBooksInLibrary - validBooks.length,
+      );
 
       // Store filtering stats for sync summary (attach to first book or create metadata)
       const filteringStats = {
@@ -613,52 +639,109 @@ export class AudiobookshelfClient {
     return [...progressItems, ...uniqueCompletedBooks];
   }
 
-  async _getLibraryItemDetails(itemId) {
+  async _getProgressBooksFromMediaProgress(mediaProgress, allowedLibraries) {
+    const allowedLibraryIds =
+      allowedLibraries && allowedLibraries.length > 0
+        ? new Set(allowedLibraries.map(lib => lib.id))
+        : null;
+
+    const progressByItemId = new Map();
+    for (const progress of mediaProgress) {
+      const itemId = this._getLibraryItemIdFromMediaProgress(progress);
+      if (!itemId) continue;
+
+      const existingProgress = progressByItemId.get(itemId);
+      progressByItemId.set(
+        itemId,
+        this._chooseMostRelevantMediaProgress(existingProgress, progress),
+      );
+    }
+
+    logger.debug('Prepared mediaProgress records for item lookup', {
+      mediaProgressCount: mediaProgress.length,
+      uniqueLibraryItems: progressByItemId.size,
+    });
+
+    const detailPromises = Array.from(progressByItemId.entries()).map(
+      ([itemId, progress]) =>
+        this._getLibraryItemDetails(itemId, progress).catch(error => {
+          if (this._isRecoverableError(error)) {
+            logger.debug(
+              'Recoverable error fetching mediaProgress item details',
+              {
+                itemId,
+                error: error.message,
+              },
+            );
+            return null;
+          }
+
+          logger.error('Critical error fetching mediaProgress item details', {
+            itemId,
+            error: error.message,
+          });
+          throw error;
+        }),
+    );
+
+    const itemDetails = (await Promise.all(detailPromises)).filter(Boolean);
+    const filteredItemDetails = allowedLibraryIds
+      ? itemDetails.filter(item => allowedLibraryIds.has(item.libraryId))
+      : itemDetails;
+
+    const excludedByLibraryFilter =
+      itemDetails.length - filteredItemDetails.length;
+    if (excludedByLibraryFilter > 0) {
+      logger.debug('Filtered mediaProgress items by library', {
+        totalFound: itemDetails.length,
+        afterFiltering: filteredItemDetails.length,
+        excludedByLibraryFilter,
+        allowedLibraries: allowedLibraries.map(lib => lib.name),
+      });
+    }
+
+    return filteredItemDetails;
+  }
+
+  _getLibraryItemIdFromMediaProgress(progress) {
+    if (!progress || typeof progress !== 'object') {
+      return null;
+    }
+
+    // Podcast episode progress uses the same model but is outside ShelfBridge's scope.
+    if (progress.episodeId) {
+      return null;
+    }
+
+    return progress.libraryItemId || progress.id || null;
+  }
+
+  _chooseMostRelevantMediaProgress(existingProgress, candidateProgress) {
+    if (!existingProgress) {
+      return candidateProgress;
+    }
+
+    if (candidateProgress.isFinished && !existingProgress.isFinished) {
+      return candidateProgress;
+    }
+
+    const existingLastUpdate = existingProgress.lastUpdate || 0;
+    const candidateLastUpdate = candidateProgress.lastUpdate || 0;
+    return candidateLastUpdate >= existingLastUpdate
+      ? candidateProgress
+      : existingProgress;
+  }
+
+  async _getLibraryItemDetails(itemId, knownProgress = null) {
     try {
       const itemData = await this._makeRequest('GET', `/api/items/${itemId}`);
 
       // Get user's progress for this item
-      const progressData = await this._getUserProgress(itemId);
+      const progressData =
+        knownProgress || (await this._getUserProgress(itemId));
 
       // Combine item data with progress
-      if (progressData) {
-        itemData.progress_percentage = progressData.progress * 100;
-        itemData.current_time = progressData.currentTime;
-        itemData.is_finished = progressData.isFinished;
-
-        // Use media progress startedAt if available
-        if (progressData.startedAt) {
-          itemData.started_at = progressData.startedAt;
-          logger.debug('Raw startedAt for book', {
-            title: itemData.media?.metadata?.title,
-            startedAt: progressData.startedAt,
-            startedAtISO: new Date(progressData.startedAt).toISOString(),
-          });
-        }
-        // Use media progress finishedAt if available
-        if (progressData.finishedAt) {
-          itemData.finished_at = progressData.finishedAt;
-          logger.debug('Raw finishedAt for book', {
-            title: itemData.media?.metadata?.title,
-            finishedAt: progressData.finishedAt,
-            finishedAtISO: new Date(progressData.finishedAt).toISOString(),
-          });
-        }
-        // Use media progress lastUpdate for last listened
-        if (progressData.lastUpdate) {
-          itemData.last_listened_at = progressData.lastUpdate;
-          logger.debug('Raw lastUpdate for book', {
-            title: itemData.media?.metadata?.title,
-            lastUpdate: progressData.lastUpdate,
-            lastUpdateISO: new Date(progressData.lastUpdate).toISOString(),
-          });
-        } else {
-          itemData.last_listened_at = null;
-          logger.debug('No lastUpdate for book', {
-            title: itemData.media?.metadata?.title,
-          });
-        }
-      }
+      this._applyProgressDataToItem(itemData, progressData);
 
       return itemData;
     } catch (error) {
@@ -679,6 +762,55 @@ export class AudiobookshelfClient {
       }
     }
   }
+
+  _applyProgressDataToItem(itemData, progressData) {
+    if (!itemData || !progressData) {
+      return;
+    }
+
+    if (progressData.progress !== null && progressData.progress !== undefined) {
+      itemData.progress_percentage = progressData.progress * 100;
+    } else if (progressData.isFinished === true) {
+      itemData.progress_percentage = 100;
+    }
+
+    itemData.current_time = progressData.currentTime;
+    itemData.is_finished = progressData.isFinished;
+
+    // Use media progress startedAt if available
+    if (progressData.startedAt) {
+      itemData.started_at = progressData.startedAt;
+      logger.debug('Raw startedAt for book', {
+        title: itemData.media?.metadata?.title,
+        startedAt: progressData.startedAt,
+        startedAtISO: new Date(progressData.startedAt).toISOString(),
+      });
+    }
+    // Use media progress finishedAt if available
+    if (progressData.finishedAt) {
+      itemData.finished_at = progressData.finishedAt;
+      logger.debug('Raw finishedAt for book', {
+        title: itemData.media?.metadata?.title,
+        finishedAt: progressData.finishedAt,
+        finishedAtISO: new Date(progressData.finishedAt).toISOString(),
+      });
+    }
+    // Use media progress lastUpdate for last listened
+    if (progressData.lastUpdate) {
+      itemData.last_listened_at = progressData.lastUpdate;
+      logger.debug('Raw lastUpdate for book', {
+        title: itemData.media?.metadata?.title,
+        lastUpdate: progressData.lastUpdate,
+        lastUpdateISO: new Date(progressData.lastUpdate).toISOString(),
+      });
+    } else {
+      itemData.last_listened_at = null;
+      logger.debug('No lastUpdate for book', {
+        title: itemData.media?.metadata?.title,
+      });
+    }
+  }
+
   async _getUserProgress(itemId) {
     try {
       // This endpoint can return 404 if there's no progress, which is normal
@@ -880,13 +1012,13 @@ export class AudiobookshelfClient {
     return { libraries: filteredLibraries, stats };
   }
 
-  async getLibraryItems(libraryId, limit = null) {
+  async getLibraryItems(libraryId, limit = undefined) {
     try {
       const allItems = [];
       let page = 0;
       let total = 0;
-      // Use the instance's maxBooksToFetch if no limit is provided
-      const effectiveLimit = limit !== null ? limit : this.maxBooksToFetch;
+      // Undefined uses the configured cap. Explicit null means no limit.
+      const effectiveLimit = limit === undefined ? this.maxBooksToFetch : limit;
       const itemsPerPage = this.pageSize; // Use configurable page size
 
       while (true) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import logger from './logger.js';
 
 export class Config {

--- a/src/progress-manager.js
+++ b/src/progress-manager.js
@@ -340,8 +340,10 @@ export class ProgressManager {
       isFinished = null,
       context = '',
       format = 'unknown',
-      _bookData = {}, // Book metadata for precise completion detection
+      bookData = null,
+      _bookData = null, // Backward-compatible alias for existing callers
     } = options;
+    const completionBookData = bookData ?? _bookData ?? {};
 
     // Explicit finished flag takes precedence for ALL formats
     if (isFinished === true || isFinished === 1) {
@@ -365,7 +367,7 @@ export class ProgressManager {
 
     // Validate progress percentage, passing isFinished flag to respect explicit completion
     const validatedProgress = this.validateProgress(progress, context, {
-      bookData: _bookData,
+      bookData: completionBookData,
       format: format,
       isFinished: isFinished,
     });
@@ -383,7 +385,7 @@ export class ProgressManager {
       threshold,
       format,
       context,
-      _bookData,
+      completionBookData,
     );
 
     if (isCompleteByProgress) {
@@ -995,7 +997,14 @@ export class ProgressManager {
    * @returns {boolean} - Whether the book is considered complete
    */
   static isBookComplete(bookData, context = '', options = {}, edition = null) {
-    const isFinished = this.extractFinishedFlag(bookData);
+    const hasFinishedFlag =
+      bookData &&
+      Object.prototype.hasOwnProperty.call(bookData, 'is_finished') &&
+      bookData.is_finished !== null &&
+      bookData.is_finished !== undefined;
+    const isFinished = hasFinishedFlag
+      ? this.extractFinishedFlag(bookData)
+      : null;
     const rawProgress = this.extractProgressPercentage(bookData);
     const bookFormat = this.getBookFormat(bookData, edition);
 

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -25,7 +25,7 @@ export class SyncManager {
 
     // Increase max listeners for AbortSignal to handle parallel processing
     // This prevents MaxListenersExceededWarning when processing many books
-    const maxBooks = this.globalConfig.max_books_to_fetch || 500;
+    const maxBooks = this.globalConfig.max_books_to_fetch ?? 500;
     const requiredListeners = Math.max(20, maxBooks + 10); // Buffer for safety
     setMaxListeners(requiredListeners, this.abortController.signal);
 
@@ -39,7 +39,7 @@ export class SyncManager {
       user.abs_url,
       user.abs_token,
       globalConfig.audiobookshelf_semaphore || 5,
-      globalConfig.max_books_to_fetch || 500,
+      globalConfig.max_books_to_fetch ?? null,
       globalConfig.page_size || 100,
       globalConfig.audiobookshelf_rate_limit || 600,
       {}, // rereadConfig - keep empty for now

--- a/src/utils/concurrency.js
+++ b/src/utils/concurrency.js
@@ -61,6 +61,7 @@ export class RateLimiter {
     this.cleanupInterval = setInterval(() => {
       this._cleanupOldCounts();
     }, 60000);
+    this.cleanupInterval.unref?.();
 
     logger.debug('RateLimiter initialized', {
       maxRequests: this.maxRequests,

--- a/src/utils/retry-manager.js
+++ b/src/utils/retry-manager.js
@@ -20,6 +20,17 @@ export const RetryStrategy = {
   CONSERVATIVE: 'conservative',
 };
 
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+]);
+
 /**
  * Configuration for retry behavior per error type
  */
@@ -31,10 +42,7 @@ const DEFAULT_RETRY_CONFIG = {
     shouldRetry: error => {
       return (
         !error.response &&
-        (error.code === 'ECONNABORTED' ||
-          error.code === 'ENOTFOUND' ||
-          error.code === 'ECONNRESET' ||
-          error.code === 'ETIMEDOUT' ||
+        (RETRYABLE_NETWORK_ERROR_CODES.has(error.code) ||
           (error.message && error.message.toLowerCase().includes('timeout')))
       );
     },
@@ -122,7 +130,7 @@ function getErrorType(error, category) {
   } else if (category === 'clientError') {
     return `Client error (${error.response?.status})`;
   } else if (category === 'network') {
-    return 'Network timeout';
+    return `Network error (${error.code || 'timeout'})`;
   } else {
     return `Unknown error (${error.response?.status || error.code})`;
   }

--- a/tests/audiobookshelf-media-progress.test.js
+++ b/tests/audiobookshelf-media-progress.test.js
@@ -1,0 +1,163 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { AudiobookshelfClient } from '../src/audiobookshelf-client.js';
+
+function createMediaProgress(id, overrides = {}) {
+  return {
+    id,
+    libraryItemId: id,
+    episodeId: null,
+    duration: 1000,
+    progress: 0.5,
+    currentTime: 500,
+    isFinished: false,
+    hideFromContinueListening: false,
+    lastUpdate: 1710000000000,
+    startedAt: 1709000000000,
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+describe('Audiobookshelf mediaProgress handling', () => {
+  it('uses /api/me mediaProgress as the authoritative source for completed counts', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+      1,
+      500,
+      100,
+      600,
+      {},
+      { include: ['Included Library'] },
+    );
+
+    const itemLibraries = new Map();
+    const mediaProgress = [];
+
+    for (let index = 0; index < 100; index++) {
+      const id = `completed-${index}`;
+      itemLibraries.set(id, 'included');
+      mediaProgress.push(
+        createMediaProgress(id, {
+          progress: 1,
+          currentTime: 1000,
+          isFinished: true,
+          finishedAt: 1710000000000 + index,
+        }),
+      );
+    }
+
+    for (let index = 0; index < 10; index++) {
+      const id = `reading-${index}`;
+      itemLibraries.set(id, 'included');
+      mediaProgress.push(
+        createMediaProgress(id, {
+          progress: 0.25,
+          currentTime: 250,
+          isFinished: false,
+        }),
+      );
+    }
+
+    for (let index = 0; index < 5; index++) {
+      const id = `excluded-${index}`;
+      itemLibraries.set(id, 'excluded');
+      mediaProgress.push(
+        createMediaProgress(id, {
+          progress: 1,
+          currentTime: 1000,
+          isFinished: true,
+          finishedAt: 1710000000000 + index,
+        }),
+      );
+    }
+
+    client._getCurrentUser = async () => ({ mediaProgress });
+    client.getLibraries = async () => [
+      { id: 'included', name: 'Included Library' },
+      { id: 'excluded', name: 'Excluded Library' },
+    ];
+
+    let progressEndpointCalls = 0;
+    client._getUserProgress = async () => {
+      progressEndpointCalls++;
+      return null;
+    };
+
+    client._makeRequest = async (_method, endpoint) => {
+      if (endpoint === '/api/libraries/included/items?limit=1&page=0') {
+        return { total: 9646 };
+      }
+
+      if (endpoint.startsWith('/api/items/')) {
+        const id = endpoint.replace('/api/items/', '');
+        return {
+          id,
+          libraryId: itemLibraries.get(id),
+          media: {
+            metadata: {
+              title: id,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    };
+
+    try {
+      const books = await client.getReadingProgress();
+      const stats = books[0]._filteringStats;
+
+      assert.strictEqual(progressEndpointCalls, 0);
+      assert.strictEqual(
+        books.filter(book => !book._isMetadataOnly).length,
+        110,
+      );
+      assert.strictEqual(stats.totalBooksInLibrary, 9646);
+      assert.strictEqual(stats.totalWithProgress, 110);
+      assert.strictEqual(stats.inProgressBooks, 10);
+      assert.strictEqual(stats.allCompletedBooks, 100);
+      assert.strictEqual(stats.booksNeverStarted, 9536);
+    } finally {
+      client.cleanup();
+    }
+  });
+
+  it('treats explicit null getLibraryItems limit as no limit', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+      1,
+      2,
+      2,
+    );
+
+    const pages = [
+      [{ id: 'book-1' }, { id: 'book-2' }],
+      [{ id: 'book-3' }, { id: 'book-4' }],
+      [{ id: 'book-5' }],
+    ];
+
+    client._makeRequest = async (_method, endpoint) => {
+      const page = Number(
+        new URL(`https://test.example${endpoint}`).searchParams.get('page'),
+      );
+      return {
+        total: 5,
+        results: pages[page] || [],
+      };
+    };
+
+    try {
+      const cappedItems = await client.getLibraryItems('library');
+      const uncappedItems = await client.getLibraryItems('library', null);
+
+      assert.strictEqual(cappedItems.length, 2);
+      assert.strictEqual(uncappedItems.length, 5);
+    } finally {
+      client.cleanup();
+    }
+  });
+});

--- a/tests/progress-manager.test.js
+++ b/tests/progress-manager.test.js
@@ -278,6 +278,22 @@ describe('ProgressManager.isComplete()', () => {
     assert.equal(result, true);
   });
 
+  it('accepts documented bookData option for precise audiobook completion', () => {
+    const bookData = {
+      current_time: 1683, // 28m 3s listened
+      media: { duration: 1800 }, // 30m total, under 2 minutes remaining
+    };
+
+    const result = ProgressManager.isComplete(93.5, {
+      threshold: 95,
+      context: 'test',
+      bookData,
+      format: 'audiobook',
+    });
+
+    assert.equal(result, true);
+  });
+
   it('detects completion based on precise pages remaining for books', () => {
     const bookData = {
       current_page: 298, // On page 298
@@ -298,6 +314,41 @@ describe('ProgressManager.isComplete()', () => {
       context: 'test',
       threshold: 95,
     });
+    assert.equal(result, false);
+  });
+});
+
+describe('ProgressManager.isBookComplete()', () => {
+  it('passes book data through for precise audiobook completion', () => {
+    const bookData = {
+      progress_percentage: 93.5,
+      current_time: 1683,
+      media: { duration: 1800 },
+    };
+
+    const result = ProgressManager.isBookComplete(
+      bookData,
+      'wrapper-precise-completion',
+      { threshold: 95 },
+    );
+
+    assert.equal(result, true);
+  });
+
+  it('respects an explicit unfinished flag over precise completion hints', () => {
+    const bookData = {
+      is_finished: false,
+      progress_percentage: 93.5,
+      current_time: 1683,
+      media: { duration: 1800 },
+    };
+
+    const result = ProgressManager.isBookComplete(
+      bookData,
+      'wrapper-explicit-unfinished',
+      { threshold: 95 },
+    );
+
     assert.equal(result, false);
   });
 });

--- a/tests/retry-manager.test.js
+++ b/tests/retry-manager.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { RetryManager } from '../src/utils/retry-manager.js';
+
+describe('RetryManager', () => {
+  it('retries ECONNREFUSED as a transient network error', async () => {
+    const retryManager = new RetryManager('TestService');
+    let attempts = 0;
+
+    const result = await retryManager.executeWithRetry(
+      async () => {
+        attempts++;
+
+        if (attempts === 1) {
+          const error = new Error('connect ECONNREFUSED 157.230.65.225:443');
+          error.code = 'ECONNREFUSED';
+          throw error;
+        }
+
+        return 'success';
+      },
+      { maxRetries: 1 },
+    );
+
+    assert.equal(result, 'success');
+    assert.equal(attempts, 2);
+  });
+});

--- a/wiki/admin/Configuration-Reference.md
+++ b/wiki/admin/Configuration-Reference.md
@@ -30,6 +30,10 @@ users:
 2. **Environment Variables** (fallback) - `SHELFBRIDGE_*`
 3. **Default Values** (lowest) - Built-in application defaults
 
+### YAML Parser Compatibility
+
+ShelfBridge parses `config/config.yaml` with `js-yaml`. Boolean-like words such as `yes`, `no`, `on`, and `off` are treated as strings; use explicit `true` or `false` for boolean settings.
+
 ## Global Configuration
 
 ### Core Sync Settings


### PR DESCRIPTION
## Summary
- Use /api/me mediaProgress as the authoritative source for Audiobookshelf progress and completion counts
- Apply library filtering after fetching item details so excluded libraries do not affect status counts
- Preserve max_books_to_fetch: null as an explicit no-limit setting and keep short-lived clients from hanging on rate-limit timers
- Add regression coverage for the completed-count mismatch reported in #175

Closes #175

## Tests
- node --test tests/audiobookshelf-media-progress.test.js
- node --test tests/completion-detection-robustness.test.js
- npm test
- npm run lint