### PR TITLE
fix: match equivalent ISBN variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "interactive": "node src/main.js interactive",
     "cron": "node src/main.js cron",
     "sync": "node src/main.js sync",
-    "test": "node --test tests/network-utilities.test.js tests/progress-manager.test.js tests/retry-manager.test.js tests/task-queue-basic.test.js tests/transaction.test.js tests/utilities.test.js tests/isbn-variant-matching.test.js",
+    "test": "node --test tests/network-utilities.test.js tests/progress-manager.test.js tests/retry-manager.test.js tests/task-queue-basic.test.js tests/transaction.test.js tests/utilities.test.js tests/isbn-variant-matching.test.js tests/search-result-auto-add-guards.test.js",
     "test:connections": "node src/main.js test",
     "test:native": "node scripts/test-native-modules.js",
     "validate:sqlite": "node scripts/validate-better-sqlite3.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "interactive": "node src/main.js interactive",
     "cron": "node src/main.js cron",
     "sync": "node src/main.js sync",
-    "test": "node --test tests/network-utilities.test.js tests/progress-manager.test.js tests/retry-manager.test.js tests/task-queue-basic.test.js tests/transaction.test.js tests/utilities.test.js",
+    "test": "node --test tests/network-utilities.test.js tests/progress-manager.test.js tests/retry-manager.test.js tests/task-queue-basic.test.js tests/transaction.test.js tests/utilities.test.js tests/isbn-variant-matching.test.js",
     "test:connections": "node src/main.js test",
     "test:native": "node scripts/test-native-modules.js",
     "validate:sqlite": "node scripts/validate-better-sqlite3.js",

--- a/src/failed-books-reporter.js
+++ b/src/failed-books-reporter.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { DateTime } from 'luxon';
 import logger from './logger.js';
+import { getIsbnVariants } from './matching/utils/text-matching.js';
 
 /**
  * Utility class for writing failed books reports to separate log files
@@ -147,8 +148,12 @@ export class FailedBooksReporter {
 
       // Identifiers
       const identifiers = [];
-      if (book.identifiers.isbn)
-        identifiers.push(`ISBN: ${book.identifiers.isbn}`);
+      if (book.identifiers.isbn) {
+        const isbnVariants = getIsbnVariants(book.identifiers.isbn);
+        identifiers.push(
+          ...isbnVariants.map(isbn => `ISBN-${isbn.length}: ${isbn}`),
+        );
+      }
       if (book.identifiers.isbn10)
         identifiers.push(`ISBN-10: ${book.identifiers.isbn10}`);
       if (book.identifiers.asin)

--- a/src/hardcover-client.js
+++ b/src/hardcover-client.js
@@ -3,6 +3,7 @@ import { RateLimiter, Semaphore } from './utils/concurrency.js';
 import { normalizeApiToken, createHttpAgent } from './utils/network.js';
 import { safeParseInt } from './utils/data.js';
 import { HardcoverRetryManager } from './utils/retry-manager.js';
+import { getIsbnVariants } from './matching/utils/text-matching.js';
 import ProgressManager from './progress-manager.js';
 import logger from './logger.js';
 
@@ -879,9 +880,15 @@ export class HardcoverClient {
   }
 
   async searchBooksByIsbn(isbn) {
+    const isbnCandidates = getIsbnVariants(isbn);
+    if (isbnCandidates.length === 0) {
+      logger.warn('Invalid ISBN provided for search:', isbn);
+      return [];
+    }
+
     const query = `
-            query searchBooksByIsbn($isbn: String!) {
-                editions(where: { _or: [{ isbn_10: { _eq: $isbn } }, { isbn_13: { _eq: $isbn } }] }) {
+            query searchBooksByIsbn($isbnCandidates: [String!]!) {
+                editions(where: { _or: [{ isbn_10: { _in: $isbnCandidates } }, { isbn_13: { _in: $isbnCandidates } }] }) {
                     id
                     isbn_10
                     isbn_13
@@ -912,7 +919,7 @@ export class HardcoverClient {
             }
         `;
 
-    const variables = { isbn };
+    const variables = { isbnCandidates };
 
     try {
       const result = await this._executeQuery(query, variables);

--- a/src/matching/book-matcher.js
+++ b/src/matching/book-matcher.js
@@ -17,7 +17,7 @@ import {
   extractAuthor,
   detectUserBookFormat,
 } from './utils/audiobookshelf-extractor.js';
-import { normalizeIsbn, normalizeAsin } from './utils/text-matching.js';
+import { getIsbnVariants, normalizeAsin } from './utils/text-matching.js';
 
 /**
  * Book Matcher - Orchestrates the multi-tier book matching process
@@ -233,12 +233,9 @@ export class BookMatcher {
         // Build identifier lookup table (ISBN, ASIN)
         // Add ISBN-10
         if (edition.isbn_10) {
-          const normalizedIsbn = normalizeIsbn(edition.isbn_10);
-          if (
-            normalizedIsbn &&
-            shouldStoreEdition(normalizedIsbn, editionWithFormat)
-          ) {
-            identifierLookup[normalizedIsbn] = {
+          for (const isbnVariant of getIsbnVariants(edition.isbn_10)) {
+            if (!shouldStoreEdition(isbnVariant, editionWithFormat)) continue;
+            identifierLookup[isbnVariant] = {
               userBook,
               edition: editionWithFormat,
             };
@@ -247,12 +244,9 @@ export class BookMatcher {
 
         // Add ISBN-13
         if (edition.isbn_13) {
-          const normalizedIsbn = normalizeIsbn(edition.isbn_13);
-          if (
-            normalizedIsbn &&
-            shouldStoreEdition(normalizedIsbn, editionWithFormat)
-          ) {
-            identifierLookup[normalizedIsbn] = {
+          for (const isbnVariant of getIsbnVariants(edition.isbn_13)) {
+            if (!shouldStoreEdition(isbnVariant, editionWithFormat)) continue;
+            identifierLookup[isbnVariant] = {
               userBook,
               edition: editionWithFormat,
             };

--- a/src/matching/index.js
+++ b/src/matching/index.js
@@ -19,6 +19,9 @@ export { TitleAuthorMatcher } from './strategies/title-author-matcher.js';
 // Export utility functions
 export {
   normalizeIsbn,
+  convertIsbn10To13,
+  convertIsbn13To10,
+  getIsbnVariants,
   normalizeAsin,
   normalizeTitle,
   normalizeAuthor,

--- a/src/matching/strategies/isbn-matcher.js
+++ b/src/matching/strategies/isbn-matcher.js
@@ -7,6 +7,7 @@
 
 import logger from '../../logger.js';
 import { extractTitle } from '../utils/audiobookshelf-extractor.js';
+import { getIsbnVariants } from '../utils/text-matching.js';
 
 /**
  * ISBN Matching Strategy - Tier 2
@@ -38,9 +39,13 @@ export class IsbnMatcher {
       return null;
     }
 
-    if (!identifierLookup[identifiers.isbn]) {
+    const isbnVariants = getIsbnVariants(identifiers.isbn);
+    const lookupIsbn = isbnVariants.find(isbn => identifierLookup[isbn]);
+
+    if (!lookupIsbn) {
       logger.debug(
         `❌ ISBN ${identifiers.isbn} not found in user's Hardcover library for ${title}`,
+        { isbnVariants },
       );
 
       // Try book-level matching if we have the necessary functions
@@ -130,10 +135,12 @@ export class IsbnMatcher {
       return null;
     }
 
-    const match = identifierLookup[identifiers.isbn];
+    const match = identifierLookup[lookupIsbn];
 
     logger.debug(`Found ISBN match for ${title}`, {
       isbn: identifiers.isbn,
+      matchedIsbn: lookupIsbn,
+      isbnVariants,
       hardcoverTitle: match.userBook?.book?.title || 'Unknown Title',
       userBookId: match.userBook?.id || 'No User Book ID',
       editionId: match.edition.id,

--- a/src/matching/strategies/title-author-matcher.js
+++ b/src/matching/strategies/title-author-matcher.js
@@ -652,17 +652,26 @@ export class TitleAuthorMatcher {
    */
   async _cacheSuccessfulMatch(userId, titleAuthorId, title, bestMatch, author) {
     try {
+      const editionId = bestMatch?.edition?.id || bestMatch?.id;
+      if (!editionId) {
+        logger.warn(`Skipping title/author cache write for "${title}"`, {
+          identifier: titleAuthorId,
+          reason: 'Match did not contain an edition ID',
+        });
+        return;
+      }
+
       await this.cache.storeEditionMapping(
         userId,
         titleAuthorId,
         title,
-        bestMatch.id,
+        editionId,
         'title_author',
         extractAuthorFromSearchResult(bestMatch) || author || '',
       );
       logger.debug(`Cached title/author match for "${title}"`, {
         identifier: titleAuthorId,
-        editionId: bestMatch.id,
+        editionId,
       });
     } catch (cacheError) {
       logger.warn(

--- a/src/matching/utils/identifier-lookup.js
+++ b/src/matching/utils/identifier-lookup.js
@@ -5,7 +5,7 @@
  * based on identifiers (ISBN, ASIN) from user library data.
  */
 
-import { normalizeIsbn, normalizeAsin } from './text-matching.js';
+import { getIsbnVariants, normalizeAsin } from './text-matching.js';
 
 /**
  * Create identifier lookup table from Hardcover user library
@@ -31,17 +31,15 @@ export function createIdentifierLookup(hardcoverBooks, formatMapper = null) {
 
       // Add ISBN-10
       if (edition.isbn_10) {
-        const normalizedIsbn = normalizeIsbn(edition.isbn_10);
-        if (normalizedIsbn) {
-          lookup[normalizedIsbn] = { userBook, edition: editionWithFormat };
+        for (const isbnVariant of getIsbnVariants(edition.isbn_10)) {
+          lookup[isbnVariant] = { userBook, edition: editionWithFormat };
         }
       }
 
       // Add ISBN-13
       if (edition.isbn_13) {
-        const normalizedIsbn = normalizeIsbn(edition.isbn_13);
-        if (normalizedIsbn) {
-          lookup[normalizedIsbn] = { userBook, edition: editionWithFormat };
+        for (const isbnVariant of getIsbnVariants(edition.isbn_13)) {
+          lookup[isbnVariant] = { userBook, edition: editionWithFormat };
         }
       }
 

--- a/src/matching/utils/text-matching.js
+++ b/src/matching/utils/text-matching.js
@@ -657,12 +657,81 @@ export {
 
 // Export normalization functions for existing ISBN/ASIN processing
 export function normalizeIsbn(isbn) {
-  if (!isbn) return null;
-  const normalized = isbn.replace(/[-\s]/g, '').toUpperCase();
+  if (isbn === null || isbn === undefined || isbn === '') return null;
+  const normalized = String(isbn).replace(/[-\s]/g, '').toUpperCase();
   if (normalized.length === 10 || normalized.length === 13) {
     return normalized;
   }
   return null;
+}
+
+export function convertIsbn13To10(isbn) {
+  const normalized = normalizeIsbn(isbn);
+  if (
+    !normalized ||
+    normalized.length !== 13 ||
+    !normalized.startsWith('978') ||
+    !/^\d{13}$/.test(normalized)
+  ) {
+    return null;
+  }
+
+  let isbn13Sum = 0;
+  for (let index = 0; index < 12; index++) {
+    isbn13Sum += Number(normalized[index]) * (index % 2 === 0 ? 1 : 3);
+  }
+  if ((10 - (isbn13Sum % 10)) % 10 !== Number(normalized[12])) {
+    return null;
+  }
+
+  const core = normalized.slice(3, 12);
+  let isbn10Sum = 0;
+  for (let index = 0; index < core.length; index++) {
+    isbn10Sum += Number(core[index]) * (10 - index);
+  }
+
+  const checkValue = (11 - (isbn10Sum % 11)) % 11;
+  return `${core}${checkValue === 10 ? 'X' : checkValue}`;
+}
+
+export function convertIsbn10To13(isbn) {
+  const normalized = normalizeIsbn(isbn);
+  if (
+    !normalized ||
+    normalized.length !== 10 ||
+    !/^\d{9}[\dX]$/.test(normalized)
+  ) {
+    return null;
+  }
+
+  let isbn10Sum = 0;
+  for (let index = 0; index < normalized.length; index++) {
+    const digit = normalized[index] === 'X' ? 10 : Number(normalized[index]);
+    isbn10Sum += digit * (10 - index);
+  }
+  if (isbn10Sum % 11 !== 0) {
+    return null;
+  }
+
+  const isbn13WithoutCheck = `978${normalized.slice(0, 9)}`;
+  let isbn13Sum = 0;
+  for (let index = 0; index < isbn13WithoutCheck.length; index++) {
+    isbn13Sum += Number(isbn13WithoutCheck[index]) * (index % 2 === 0 ? 1 : 3);
+  }
+
+  return `${isbn13WithoutCheck}${(10 - (isbn13Sum % 10)) % 10}`;
+}
+
+export function getIsbnVariants(isbn) {
+  const normalized = normalizeIsbn(isbn);
+  if (!normalized) return [];
+
+  const equivalent =
+    normalized.length === 10
+      ? convertIsbn10To13(normalized)
+      : convertIsbn13To10(normalized);
+
+  return [...new Set([normalized, equivalent].filter(Boolean))];
 }
 
 export function normalizeAsin(asin) {

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -409,6 +409,15 @@ export class SyncManager {
     return absBook?.last_listened_at ?? absBook?.lastUpdate ?? null;
   }
 
+  _getSearchResultBookId(hardcoverMatch) {
+    return (
+      hardcoverMatch?.userBook?.book?.id ||
+      hardcoverMatch?.book?.id ||
+      hardcoverMatch?.edition?.book?.id ||
+      null
+    );
+  }
+
   _getSkipCacheKey(title, author, identifiers = {}) {
     if (identifiers.asin) {
       return { identifier: identifiers.asin, identifierType: 'asin' };
@@ -1736,6 +1745,25 @@ export class SyncManager {
             ? 'ISBN match'
             : 'title/author match';
 
+      if (!this.globalConfig.auto_add_books) {
+        syncResult.actions.push(
+          `${matchDescription} found, but auto-add is disabled`,
+        );
+        syncResult.status = 'skipped';
+        syncResult.reason =
+          'Book not in Hardcover library and auto_add_books disabled';
+        syncResult.timing = performance.now() - startTime;
+        await this._storeNegativeSyncSkip(
+          absBook,
+          title,
+          author,
+          identifiers,
+          progressPercent,
+          'not_found_auto_add_disabled',
+        );
+        return syncResult;
+      }
+
       // Check if book meets minimum progress threshold before auto-adding
       if (this._isZeroProgress(progressPercent)) {
         logger.debug(
@@ -1770,8 +1798,8 @@ export class SyncManager {
       );
 
       // For search results, userBook might be null (ASIN/ISBN matches) or populated (title/author matches)
-      let bookId = hardcoverMatch.userBook?.book?.id;
-      const editionId = hardcoverMatch.edition.id;
+      let bookId = this._getSearchResultBookId(hardcoverMatch);
+      const editionId = hardcoverMatch.edition?.id;
 
       // If book ID is missing, look it up from the edition ID
       if (!bookId && hardcoverMatch._needsBookIdLookup) {

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -8,6 +8,7 @@ import {
   extractAuthor,
   extractBookIdentifiers,
   extractTitle,
+  getIsbnVariants,
 } from './matching/index.js';
 import { formatDurationForLogging } from './utils/time.js';
 import { DateTime } from 'luxon';
@@ -597,7 +598,9 @@ export class SyncManager {
       possibleCacheKeys.push({ key: identifiers.asin, type: 'asin' });
     }
     if (identifiers.isbn) {
-      possibleCacheKeys.push({ key: identifiers.isbn, type: 'isbn' });
+      for (const isbnVariant of getIsbnVariants(identifiers.isbn)) {
+        possibleCacheKeys.push({ key: isbnVariant, type: 'isbn' });
+      }
     }
     possibleCacheKeys.push({
       key: this.cache.generateTitleAuthorIdentifier(title, author),
@@ -993,7 +996,9 @@ export class SyncManager {
           possibleCacheKeys.push({ key: identifiers.asin, type: 'asin' });
         }
         if (identifiers.isbn) {
-          possibleCacheKeys.push({ key: identifiers.isbn, type: 'isbn' });
+          for (const isbnVariant of getIsbnVariants(identifiers.isbn)) {
+            possibleCacheKeys.push({ key: isbnVariant, type: 'isbn' });
+          }
         }
 
         // For title/author matching, add the standardized title/author cache identifier
@@ -1483,7 +1488,9 @@ export class SyncManager {
       possibleCacheKeys.push({ key: identifiers.asin, type: 'asin' });
     }
     if (identifiers.isbn) {
-      possibleCacheKeys.push({ key: identifiers.isbn, type: 'isbn' });
+      for (const isbnVariant of getIsbnVariants(identifiers.isbn)) {
+        possibleCacheKeys.push({ key: isbnVariant, type: 'isbn' });
+      }
     }
 
     // Add title/author key using consistent pattern (same as TitleAuthorMatcher)
@@ -1504,6 +1511,7 @@ export class SyncManager {
 
     let cachedInfo = { exists: false };
     let cacheSource = null;
+    let cachedIdentifier = null;
 
     try {
       // Try each possible cache key until we find a match
@@ -1523,6 +1531,7 @@ export class SyncManager {
         if (cacheResult.exists) {
           cachedInfo = cacheResult;
           cacheSource = type;
+          cachedIdentifier = key;
           logger.debug(`Cache hit with ${type} key for "${title}"`, {
             key: key,
             lastSync: cachedInfo.last_sync,
@@ -1569,7 +1578,7 @@ export class SyncManager {
       );
     } else {
       // Use identifier priority for books matched by ASIN/ISBN: ASIN > ISBN > title_author
-      identifier = identifiers.asin || identifiers.isbn;
+      identifier = cachedIdentifier || identifiers.asin || identifiers.isbn;
       identifierType = identifiers.asin ? 'asin' : 'isbn';
 
       if (!identifier) {
@@ -2420,8 +2429,12 @@ export class SyncManager {
           // Track this failure for reporting
           if (result) {
             const searchedIdentifiersList = [];
-            if (identifiers.isbn)
-              searchedIdentifiersList.push(`ISBN: ${identifiers.isbn}`);
+            if (identifiers.isbn) {
+              const isbnVariants = getIsbnVariants(identifiers.isbn);
+              searchedIdentifiersList.push(
+                ...isbnVariants.map(isbn => `ISBN-${isbn.length}: ${isbn}`),
+              );
+            }
             if (identifiers.isbn10)
               searchedIdentifiersList.push(`ISBN-10: ${identifiers.isbn10}`);
             if (identifiers.asin)

--- a/tests/isbn-variant-matching.test.js
+++ b/tests/isbn-variant-matching.test.js
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { FailedBooksReporter } from '../src/failed-books-reporter.js';
+import { HardcoverClient } from '../src/hardcover-client.js';
+import { IsbnMatcher } from '../src/matching/strategies/isbn-matcher.js';
+import { createIdentifierLookup } from '../src/matching/utils/identifier-lookup.js';
+import { SyncManager } from '../src/sync-manager.js';
+import {
+  convertIsbn10To13,
+  convertIsbn13To10,
+  getIsbnVariants,
+  normalizeIsbn,
+} from '../src/matching/utils/text-matching.js';
+
+describe('ISBN variant matching', () => {
+  it('converts the ISBN pair reported in issue #181', () => {
+    assert.equal(convertIsbn10To13('0575082011'), '9780575082014');
+    assert.equal(convertIsbn13To10('9780575082014'), '0575082011');
+    assert.deepEqual(getIsbnVariants('0575082011'), [
+      '0575082011',
+      '9780575082014',
+    ]);
+    assert.deepEqual(getIsbnVariants('978-0-575-08201-4'), [
+      '9780575082014',
+      '0575082011',
+    ]);
+  });
+
+  it('normalizes numeric ISBN values returned by an API', () => {
+    assert.equal(normalizeIsbn(9780575082014), '9780575082014');
+  });
+
+  it('does not invent equivalents for invalid checksums or 979 ISBNs', () => {
+    assert.deepEqual(getIsbnVariants('9780575082015'), ['9780575082015']);
+    assert.deepEqual(getIsbnVariants('0575082012'), ['0575082012']);
+    assert.deepEqual(getIsbnVariants('9791234567896'), ['9791234567896']);
+  });
+
+  it('indexes an ISBN-10-only Hardcover edition by its ISBN-13 equivalent', () => {
+    const userBook = {
+      id: 'user-book-before-they-are-hanged',
+      book: {
+        editions: [
+          {
+            id: 'edition-isbn10-only',
+            isbn_10: '0575082011',
+            isbn_13: null,
+          },
+        ],
+      },
+    };
+
+    const lookup = createIdentifierLookup([userBook]);
+
+    assert.equal(lookup['0575082011'].edition.id, 'edition-isbn10-only');
+    assert.equal(lookup['9780575082014'].edition.id, 'edition-isbn10-only');
+  });
+
+  it('matches an ABS ISBN-13 to a Hardcover ISBN-10 lookup entry', async () => {
+    const matcher = new IsbnMatcher();
+    const userBook = {
+      id: 'user-book-before-they-are-hanged',
+      book: { title: 'Before They Are Hanged' },
+    };
+    const edition = { id: 'edition-isbn10-only', isbn_10: '0575082011' };
+
+    const match = await matcher.findMatch(
+      { media: { metadata: { title: 'Before They Are Hanged' } } },
+      { isbn: '9780575082014', asin: null },
+      { '0575082011': { userBook, edition } },
+    );
+
+    assert.equal(match.userBook.id, userBook.id);
+    assert.equal(match.edition.id, edition.id);
+    assert.equal(match._matchType, 'isbn');
+  });
+
+  it('queries Hardcover with both equivalent ISBN forms', async () => {
+    const client = new HardcoverClient('test-token');
+    let capturedVariables;
+
+    client._executeQuery = async (_query, variables) => {
+      capturedVariables = variables;
+      return { editions: [] };
+    };
+
+    try {
+      await client.searchBooksByIsbn('9780575082014');
+      assert.deepEqual(capturedVariables.isbnCandidates, [
+        '9780575082014',
+        '0575082011',
+      ]);
+    } finally {
+      client.cleanup();
+    }
+  });
+
+  it('reuses cache entries stored under the other ISBN form', async () => {
+    const checkedKeys = [];
+    const manager = Object.create(SyncManager.prototype);
+    manager.userId = 'test-user';
+    manager.cache = {
+      generateTitleAuthorIdentifier: () => 'title-author-key',
+      getCachedBookInfo: async (_userId, key) => {
+        checkedKeys.push(key);
+        return key === '0575082011'
+          ? { exists: true, edition_id: 'edition-1' }
+          : { exists: false };
+      },
+      hasProgressChanged: async () => false,
+    };
+    manager._findUserBookByEditionId = () => ({ id: 'user-book-1' });
+
+    const priority = await manager._getDirectCachedSyncPriority({
+      id: 'abs-book-1',
+      progress_percentage: 50,
+      media: {
+        metadata: {
+          title: 'Before They Are Hanged',
+          authors: [{ name: 'Joe Abercrombie' }],
+          isbn: '9780575082014',
+        },
+      },
+    });
+
+    assert.equal(priority, 1);
+    assert.deepEqual(checkedKeys, ['9780575082014', '0575082011']);
+  });
+
+  it('shows both equivalent forms in failed-book reports', () => {
+    const report = FailedBooksReporter._buildReport(
+      [
+        {
+          title: 'Before They Are Hanged',
+          author: 'Joe Abercrombie',
+          identifiers: { isbn: '9780575082014' },
+          category: 'NOT_FOUND',
+          reason: 'Book not found',
+          suggestions: [],
+          details: {},
+        },
+      ],
+      { books_not_found: 1 },
+    );
+
+    assert.match(
+      report,
+      /Identifiers: ISBN-13: 9780575082014, ISBN-10: 0575082011/,
+    );
+  });
+});

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { SyncManager } from '../src/sync-manager.js';
+import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matcher.js';
+
+function createTwoStageMatch() {
+  return {
+    userBook: null,
+    book: {
+      id: 292354,
+      title: 'The Martian',
+    },
+    edition: {
+      id: 30402186,
+      format: 'Listened',
+    },
+    _matchType: 'title_author_two_stage',
+    _isSearchResult: true,
+  };
+}
+
+describe('Search-result auto-add guards', () => {
+  it('uses the top-level book ID returned by two-stage matching', () => {
+    const manager = Object.create(SyncManager.prototype);
+
+    assert.equal(manager._getSearchResultBookId(createTwoStageMatch()), 292354);
+  });
+
+  it('does not auto-add search results when auto_add_books is disabled', async () => {
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+    const storeNegativeSyncSkip = mock.fn(async () => {});
+    const manager = Object.create(SyncManager.prototype);
+
+    Object.assign(manager, {
+      userId: 'test-user',
+      dryRun: false,
+      verbose: false,
+      timezone: 'UTC',
+      globalConfig: {
+        force_sync: true,
+        auto_add_books: false,
+        min_progress_threshold: 5,
+      },
+      bookMatcher: {
+        findMatch: mock.fn(async () => ({
+          match: createTwoStageMatch(),
+          extractedMetadata: {},
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_martian|andy_weir',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      hardcover: { addBookToLibrary },
+      _storeNegativeSyncSkip: storeNegativeSyncSkip,
+    });
+
+    const result = await manager._syncSingleBook(
+      {
+        id: 'abs-the-martian',
+        progress_percentage: 100,
+        media: {
+          metadata: {
+            title: 'The Martian',
+            authors: [{ name: 'Andy Weir' }],
+          },
+        },
+      },
+      null,
+    );
+
+    assert.equal(result.status, 'skipped');
+    assert.equal(
+      result.reason,
+      'Book not in Hardcover library and auto_add_books disabled',
+    );
+    assert.equal(addBookToLibrary.mock.callCount(), 0);
+    assert.equal(storeNegativeSyncSkip.mock.callCount(), 1);
+    assert.equal(
+      storeNegativeSyncSkip.mock.calls[0].arguments.at(-1),
+      'not_found_auto_add_disabled',
+    );
+  });
+
+  it('auto-adds a two-stage match with its returned top-level book ID', async () => {
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+    const syncExistingBook = mock.fn(async () => ({
+      status: 'synced',
+      reason: 'test sync',
+    }));
+    const manager = Object.create(SyncManager.prototype);
+
+    Object.assign(manager, {
+      userId: 'test-user',
+      dryRun: false,
+      verbose: false,
+      timezone: 'UTC',
+      globalConfig: {
+        force_sync: true,
+        auto_add_books: true,
+        min_progress_threshold: 5,
+      },
+      bookMatcher: {
+        findMatch: mock.fn(async () => ({
+          match: createTwoStageMatch(),
+          extractedMetadata: {},
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_martian|andy_weir',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      hardcover: { addBookToLibrary },
+      sessionManager: {
+        shouldDelayUpdate: mock.fn(async () => ({
+          shouldDelay: false,
+          reason: 'test sync',
+        })),
+        completeSession: mock.fn(async () => false),
+      },
+      _syncExistingBook: syncExistingBook,
+      _clearNegativeSyncSkip: mock.fn(async () => {}),
+    });
+
+    const result = await manager._syncSingleBook(
+      {
+        id: 'abs-the-martian',
+        progress_percentage: 100,
+        media: {
+          metadata: {
+            title: 'The Martian',
+            authors: [{ name: 'Andy Weir' }],
+          },
+        },
+      },
+      null,
+    );
+
+    assert.equal(result.status, 'synced');
+    assert.equal(addBookToLibrary.mock.callCount(), 1);
+    assert.deepEqual(
+      addBookToLibrary.mock.calls[0].arguments,
+      [292354, 2, 30402186],
+    );
+    assert.equal(syncExistingBook.mock.callCount(), 1);
+  });
+
+  it('caches the edition ID from a two-stage match', async () => {
+    const storeEditionMapping = mock.fn(async () => {});
+    const matcher = new TitleAuthorMatcher(null, { storeEditionMapping }, {});
+
+    await matcher._cacheSuccessfulMatch(
+      'test-user',
+      'title_author:the_martian|andy_weir',
+      'The Martian',
+      createTwoStageMatch(),
+      'Andy Weir',
+    );
+
+    assert.equal(storeEditionMapping.mock.callCount(), 1);
+    assert.equal(storeEditionMapping.mock.calls[0].arguments[3], 30402186);
+  });
+
+  it('does not overwrite a cache mapping when the edition ID is absent', async () => {
+    const storeEditionMapping = mock.fn(async () => {});
+    const matcher = new TitleAuthorMatcher(null, { storeEditionMapping }, {});
+
+    await matcher._cacheSuccessfulMatch(
+      'test-user',
+      'title_author:the_martian|andy_weir',
+      'The Martian',
+      { book: { id: 292354 } },
+      'Andy Weir',
+    );
+
+    assert.equal(storeEditionMapping.mock.callCount(), 0);
+  });
+});


### PR DESCRIPTION
## Summary
- convert between checksum-valid ISBN-10 and ISBN-13 forms
- search and match Hardcover editions using both equivalent identifiers
- reuse cache entries stored under either ISBN form
- show both forms in failed-book reports
- preserve top-level book IDs returned by two-stage title/author matching
- enforce auto_add_books for search-result matches
- prevent incomplete matches from overwriting cached edition mappings
- add regressions for issue #181 and the observed The Martian failure

## Validation
- npm test (141 passed)
- cache-focused tests (21 passed)
- npm run lint
- npm run format:check

Closes #181