### PR TITLE
fix: verify platform-specific Docker image digests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,44 +132,28 @@ jobs:
         run: |
           run_native_test() {
             local platform="$1"
-            local attempt
-            local status
+            local platform_digest="$2"
 
-            for attempt in 1 2 3; do
-              echo "🧪 Testing native module on $platform (attempt $attempt/3)..."
-
-              set +e
-              docker run --rm --pull=always --platform "$platform" --entrypoint="" \
-                "$IMAGE@$DIGEST" npm run test:native
-              status=$?
-              set -e
-
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-
-              # Exit 125 means Docker could not start the container. This can
-              # happen briefly while a newly pushed manifest propagates through
-              # GHCR. Application test failures must still fail immediately.
-              if [ "$status" -ne 125 ] || [ "$attempt" -eq 3 ]; then
-                echo "::error::Native module verification failed for $platform with exit code $status"
-                return "$status"
-              fi
-
-              echo "::warning::Docker could not start the $platform image; retrying after registry propagation delay"
-              sleep "$((attempt * 10))"
-            done
+            echo "🧪 Testing native module on $platform..."
+            docker run --rm --pull=always --platform "$platform" --entrypoint="" \
+              "$IMAGE@$platform_digest" npm run test:native
           }
 
           echo "🔍 Verifying multi-architecture manifest..."
-          platforms=$(docker buildx imagetools inspect --raw "$IMAGE@$DIGEST" |
-            jq -r '.manifests[] | select(.platform.os != "unknown") | "\(.platform.os)/\(.platform.architecture)"')
+          manifest=$(docker buildx imagetools inspect --raw "$IMAGE@$DIGEST")
+          platforms=$(jq -r '.manifests[] | select(.platform.os != "unknown") | "\(.platform.os)/\(.platform.architecture)"' <<< "$manifest")
           echo "$platforms"
           grep -qx 'linux/amd64' <<< "$platforms"
           grep -qx 'linux/arm64' <<< "$platforms"
 
-          run_native_test linux/amd64
-          run_native_test linux/arm64
+          amd64_digest=$(jq -er '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")][0].digest' <<< "$manifest")
+          arm64_digest=$(jq -er '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")][0].digest' <<< "$manifest")
+
+          # Each architecture must use its child-manifest digest. Reusing the
+          # multi-arch index digest makes Docker reject the second platform with
+          # "cannot overwrite digest" after the first platform is pulled.
+          run_native_test linux/amd64 "$amd64_digest"
+          run_native_test linux/arm64 "$arm64_digest"
 
           echo "✅ Multi-architecture image verified"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,37 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/shelfbridge
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          run_native_test() {
+            local platform="$1"
+            local attempt
+            local status
+
+            for attempt in 1 2 3; do
+              echo "🧪 Testing native module on $platform (attempt $attempt/3)..."
+
+              set +e
+              docker run --rm --pull=always --platform "$platform" --entrypoint="" \
+                "$IMAGE@$DIGEST" npm run test:native
+              status=$?
+              set -e
+
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+
+              # Exit 125 means Docker could not start the container. This can
+              # happen briefly while a newly pushed manifest propagates through
+              # GHCR. Application test failures must still fail immediately.
+              if [ "$status" -ne 125 ] || [ "$attempt" -eq 3 ]; then
+                echo "::error::Native module verification failed for $platform with exit code $status"
+                return "$status"
+              fi
+
+              echo "::warning::Docker could not start the $platform image; retrying after registry propagation delay"
+              sleep "$((attempt * 10))"
+            done
+          }
+
           echo "🔍 Verifying multi-architecture manifest..."
           platforms=$(docker buildx imagetools inspect --raw "$IMAGE@$DIGEST" |
             jq -r '.manifests[] | select(.platform.os != "unknown") | "\(.platform.os)/\(.platform.architecture)"')
@@ -137,11 +168,8 @@ jobs:
           grep -qx 'linux/amd64' <<< "$platforms"
           grep -qx 'linux/arm64' <<< "$platforms"
 
-          echo "🧪 Testing native module on AMD64..."
-          docker run --rm --platform linux/amd64 --entrypoint="" "$IMAGE@$DIGEST" npm run test:native
-
-          echo "🧪 Testing native module on ARM64..."
-          docker run --rm --platform linux/arm64 --entrypoint="" "$IMAGE@$DIGEST" npm run test:native
+          run_native_test linux/amd64
+          run_native_test linux/arm64
 
           echo "✅ Multi-architecture image verified"
 


### PR DESCRIPTION
## Summary

- inspect the published OCI index and resolve the unique child-manifest digest for linux/amd64 and linux/arm64
- run native-module verification against each architecture-specific digest
- avoid reusing the multi-architecture index digest for two different local platform pulls

## Root cause

Release run 29418222303 successfully built, pushed, attested, and verified the AMD64 v1.23.5 image. The subsequent ARM64 pull reused the same multi-architecture index digest, and Docker rejected replacing its local AMD64 association with ARM64:

`docker: cannot overwrite digest sha256:1601e7...`

This was deterministic, not a transient GHCR propagation failure. Each verification now uses its platform's child-manifest digest, so Docker stores the two images under distinct immutable references.

## Validation

- release workflow parses as valid YAML
- embedded shell passes `bash -n`
- published linux/amd64 child-manifest test passes
- published linux/arm64 child-manifest test passes immediately afterward

Failed job: https://github.com/rohit-purandare/ShelfBridge/actions/runs/29418222303/job/87361765998