### PR TITLE
fix: validate Docker placeholders from YAML values

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -169,8 +169,11 @@ echo ""
 if [ -f "/app/config/config.yaml" ]; then
     echo "🔍 Checking configuration for placeholder values..."
 
-    # Check for common placeholder patterns
-    if grep -q "your-audiobookshelf-server.com\|your_audiobookshelf_api_token\|your_hardcover_api_token\|your_username" /app/config/config.yaml; then
+    # Parse YAML and inspect only configured user fields, ignoring comments.
+    placeholder_status=0
+    node /app/scripts/check-config-placeholders.js /app/config/config.yaml || placeholder_status=$?
+
+    if [ "$placeholder_status" -eq 1 ]; then
         echo ""
         echo "❌ CONFIGURATION ERROR: Placeholder values detected in config.yaml"
         echo ""
@@ -196,9 +199,11 @@ if [ -f "/app/config/config.yaml" ]; then
         echo ""
         echo "🚫 Exiting until configuration is updated..."
         exit 0
+    elif [ "$placeholder_status" -gt 1 ]; then
+        echo "⚠️  Placeholder pre-check could not parse config.yaml; application validation will report details"
+    else
+        echo "✅ Configuration validation passed - no placeholder values found"
     fi
-
-    echo "✅ Configuration validation passed - no placeholder values found"
 fi
 
 # Drop privileges when running as root, otherwise run as current user in order to support a custom specified docker user

--- a/scripts/check-config-placeholders.js
+++ b/scripts/check-config-placeholders.js
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import * as yaml from 'js-yaml';
+
+import { findUserPlaceholderValues } from '../src/config-placeholders.js';
+
+const configPath = process.argv[2];
+
+if (!configPath) {
+  console.error('Usage: node scripts/check-config-placeholders.js <config>');
+  process.exit(2);
+}
+
+try {
+  const config = yaml.load(fs.readFileSync(configPath, 'utf8')) || {};
+  const placeholders = findUserPlaceholderValues(config.users);
+
+  if (placeholders.length > 0) {
+    for (const { index, field } of placeholders) {
+      console.error(`Placeholder detected in users[${index}].${field}`);
+    }
+    process.exit(1);
+  }
+
+  process.exit(0);
+} catch (error) {
+  console.error(`Unable to inspect configuration: ${error.message}`);
+  process.exit(2);
+}

--- a/src/config-placeholders.js
+++ b/src/config-placeholders.js
@@ -1,0 +1,69 @@
+export const PLACEHOLDER_PATTERNS = {
+  urls: [
+    'your-audiobookshelf-server.com',
+    'your-abs-server.com',
+    'your-server.com',
+    'localhost.example.com',
+    'example.com',
+    'your-domain.com',
+    'audiobookshelf.example.com',
+  ],
+  tokens: [
+    'your_audiobookshelf_api_token',
+    'your_audiobookshelf_token',
+    'your_abs_token',
+    'your_hardcover_api_token',
+    'your_hardcover_token',
+    'your_token_here',
+    'abc123',
+    'xyz789',
+    'token123',
+    'api_token_here',
+    'your_api_key',
+    'your_api_token',
+    'bearer your_audiobookshelf_api_token',
+    'bearer your_hardcover_api_token',
+    'bearer your_token_here',
+  ],
+  userIds: ['your_username', 'your_user_id', 'user_id_here', 'username_here'],
+};
+
+const USER_PLACEHOLDER_FIELDS = {
+  abs_url: 'urls',
+  abs_token: 'tokens',
+  hardcover_token: 'tokens',
+  id: 'userIds',
+};
+
+export function isPlaceholderValue(value, category) {
+  if (!value || typeof value !== 'string') {
+    return false;
+  }
+
+  const patterns = PLACEHOLDER_PATTERNS[category] || [];
+  const lowerValue = value.toLowerCase();
+
+  return patterns.some(pattern => lowerValue.includes(pattern.toLowerCase()));
+}
+
+export function findUserPlaceholderValues(users) {
+  if (!Array.isArray(users)) {
+    return [];
+  }
+
+  const placeholders = [];
+
+  users.forEach((user, index) => {
+    if (!user || typeof user !== 'object') {
+      return;
+    }
+
+    for (const [field, category] of Object.entries(USER_PLACEHOLDER_FIELDS)) {
+      if (isPlaceholderValue(user[field], category)) {
+        placeholders.push({ index, field, value: user[field] });
+      }
+    }
+  });
+
+  return placeholders;
+}

--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -1,47 +1,15 @@
 import cron from 'node-cron';
 import { DateTime } from 'luxon';
 import { testApiConnections } from './utils/api-testing.js';
+import {
+  isPlaceholderValue,
+  PLACEHOLDER_PATTERNS,
+} from './config-placeholders.js';
 
 export class ConfigValidator {
   constructor() {
     // Common placeholder patterns to detect
-    this.placeholderPatterns = {
-      urls: [
-        'your-audiobookshelf-server.com',
-        'your-abs-server.com',
-        'your-server.com',
-        'localhost.example.com',
-        'example.com',
-        'your-domain.com',
-        'audiobookshelf.example.com',
-      ],
-      tokens: [
-        'your_audiobookshelf_api_token',
-        'your_audiobookshelf_token',
-        'your_abs_token',
-        'your_hardcover_api_token',
-        'your_hardcover_token',
-        'your_token_here',
-        'abc123',
-        'xyz789',
-        'token123',
-        'api_token_here',
-        'your_api_key',
-        'your_api_token',
-        'bearer your_audiobookshelf_api_token',
-        'bearer your_hardcover_api_token',
-        'bearer your_token_here',
-        'Bearer your_audiobookshelf_api_token',
-        'Bearer your_hardcover_api_token',
-        'Bearer your_token_here',
-      ],
-      userIds: [
-        'your_username',
-        'your_user_id',
-        'user_id_here',
-        'username_here',
-      ],
-    };
+    this.placeholderPatterns = PLACEHOLDER_PATTERNS;
 
     this.schema = {
       global: {
@@ -1030,17 +998,7 @@ export class ConfigValidator {
    * Check if a value matches a placeholder pattern
    */
   isPlaceholderValue(value, category) {
-    if (!value || typeof value !== 'string') {
-      return false;
-    }
-
-    const patterns = this.placeholderPatterns[category] || [];
-    const lowerValue = value.toLowerCase();
-
-    return patterns.some(
-      pattern =>
-        lowerValue.includes(pattern.toLowerCase()) || value === pattern,
-    );
+    return isPlaceholderValue(value, category);
   }
 
   /**

--- a/tests/config-placeholders.test.js
+++ b/tests/config-placeholders.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import * as yaml from 'js-yaml';
+
+import {
+  findUserPlaceholderValues,
+  isPlaceholderValue,
+} from '../src/config-placeholders.js';
+
+describe('configuration placeholder detection', () => {
+  it('ignores placeholder text outside configured user fields', () => {
+    const config = yaml.load(`
+users:
+  - id: rohit
+    abs_url: https://audiobooks.example.net
+    abs_token: real-abs-token
+    hardcover_token: real-hardcover-token
+    # Run 'node src/main.js debug -u your_username' for help
+`);
+
+    assert.deepEqual(findUserPlaceholderValues(config.users), []);
+  });
+
+  it('reports placeholders in each supported user field', () => {
+    const users = [
+      {
+        id: 'your_username',
+        abs_url: 'https://your-audiobookshelf-server.com',
+        abs_token: 'your_audiobookshelf_api_token_here',
+        hardcover_token: 'your_hardcover_api_token_here',
+      },
+    ];
+
+    assert.deepEqual(
+      findUserPlaceholderValues(users).map(({ field }) => field),
+      ['abs_url', 'abs_token', 'hardcover_token', 'id'],
+    );
+  });
+
+  it('matches placeholder values case-insensitively', () => {
+    assert.equal(
+      isPlaceholderValue('Bearer YOUR_HARDCOVER_API_TOKEN', 'tokens'),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- parse config.yaml and inspect only configured user credential fields
- ignore placeholder text in YAML comments and unrelated fields
- share placeholder patterns with the application validator
- add regression coverage for the reported false positive

## Validation

- node --test tests/config-placeholders.test.js
- npm run lint
- Prettier check
- sh -n docker-entrypoint.sh

The full local suite was also attempted, but the checkout has an existing better-sqlite3 Node ABI mismatch that prevents a clean full-suite result.

Fixes #191