### PR TITLE
fix: clarify Hardcover authentication errors

### DIFF
--- a/src/hardcover-client.js
+++ b/src/hardcover-client.js
@@ -1483,6 +1483,16 @@ export class HardcoverClient {
         }
 
         if (response.status < 200 || response.status >= 300) {
+          if (response.status === 401) {
+            const error = new Error(
+              'Hardcover authentication failed (HTTP 401 Unauthorized). Check that your Hardcover API token is valid and current, then update hardcover_token or SHELFBRIDGE_USER_<N>_HARDCOVER_TOKEN. Generate a new token at https://hardcover.app/account/developer if needed.',
+            );
+            error.name = 'HardcoverAuthenticationError';
+            error.code = 'HARDCOVER_AUTHENTICATION_FAILED';
+            error.statusCode = response.status;
+            throw error;
+          }
+
           throw new Error(
             `GraphQL API request failed with status ${response.status}: ${response.statusText}`,
           );

--- a/tests/hardcover-authentication-error.test.js
+++ b/tests/hardcover-authentication-error.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { HardcoverClient } from '../src/hardcover-client.js';
+
+describe('Hardcover authentication errors', () => {
+  let client;
+
+  afterEach(() => {
+    client?.cleanup();
+  });
+
+  it('explains how to resolve an HTTP 401 without exposing the token', async () => {
+    const token = 'secret-hardcover-token';
+    client = new HardcoverClient(token);
+    client.client.post = async () => ({
+      status: 401,
+      statusText: 'Unauthorized',
+      data: {},
+    });
+
+    await assert.rejects(client._executeQuery('query { me { id } }'), error => {
+      assert.equal(error.name, 'HardcoverAuthenticationError');
+      assert.equal(error.code, 'HARDCOVER_AUTHENTICATION_FAILED');
+      assert.equal(error.statusCode, 401);
+      assert.match(error.message, /Hardcover authentication failed/);
+      assert.match(error.message, /Hardcover API token/);
+      assert.match(error.message, /hardcover_token/);
+      assert.match(error.message, /SHELFBRIDGE_USER_<N>_HARDCOVER_TOKEN/);
+      assert.match(error.message, /hardcover\.app\/account\/developer/);
+      assert.doesNotMatch(error.message, new RegExp(token));
+      return true;
+    });
+  });
+
+  it('retains the generic GraphQL error for other HTTP failures', async () => {
+    client = new HardcoverClient('secret-hardcover-token');
+    client.client.post = async () => ({
+      status: 403,
+      statusText: 'Forbidden',
+      data: {},
+    });
+
+    await assert.rejects(
+      client._executeQuery('query { me { id } }'),
+      /GraphQL API request failed with status 403: Forbidden/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- replace the generic GraphQL 401 error with an actionable Hardcover authentication error
- identify the supported YAML and environment token settings and link to Hardcover token generation
- attach a stable error code and status without exposing the configured token
- add regression coverage for 401 handling and unchanged behavior for other HTTP failures

## Testing

- `node --test tests/hardcover-authentication-error.test.js`
- `npm run lint`
- `npx prettier --check src/hardcover-client.js tests/hardcover-authentication-error.test.js`
- `git diff --check`

`npm test` was also run, but the full local suite is blocked by the installed `better-sqlite3` binary targeting Node module ABI 137 while the active Node.js runtime requires ABI 147.