### PR TITLE
fix: resolve abort listener accumulation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "js-yaml": "5.0.0",
         "luxon": "^3.7.1",
         "node-cron": "^4.2.1",
-        "p-queue": "^8.1.0",
+        "p-queue": "^9.3.1",
         "rate-limiter-flexible": "^7.2.0",
         "winston": "^3.17.0",
         "winston-daily-rotate-file": "^4.7.1"
@@ -1479,9 +1479,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/expand-template": {
@@ -2566,28 +2566,28 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
+      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "js-yaml": "5.0.0",
     "luxon": "^3.7.1",
     "node-cron": "^4.2.1",
-    "p-queue": "^8.1.0",
+    "p-queue": "^9.3.1",
     "rate-limiter-flexible": "^7.2.0",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^4.7.1"

--- a/src/audiobookshelf-client.js
+++ b/src/audiobookshelf-client.js
@@ -662,26 +662,38 @@ export class AudiobookshelfClient {
       uniqueLibraryItems: progressByItemId.size,
     });
 
-    const detailPromises = Array.from(progressByItemId.entries()).map(
-      ([itemId, progress]) =>
-        this._getLibraryItemDetails(itemId, progress).catch(error => {
-          if (this._isRecoverableError(error)) {
-            logger.debug(
-              'Recoverable error fetching mediaProgress item details',
-              {
-                itemId,
-                error: error.message,
-              },
-            );
-            return null;
-          }
+    const progressEntries = Array.from(progressByItemId.entries());
+    const cappedProgressEntries =
+      this.maxBooksToFetch === null
+        ? progressEntries
+        : progressEntries.slice(0, this.maxBooksToFetch);
 
-          logger.error('Critical error fetching mediaProgress item details', {
-            itemId,
-            error: error.message,
-          });
-          throw error;
-        }),
+    if (cappedProgressEntries.length < progressEntries.length) {
+      logger.debug('Limited mediaProgress item detail fetches', {
+        totalFound: progressEntries.length,
+        maxBooksToFetch: this.maxBooksToFetch,
+      });
+    }
+
+    const detailPromises = cappedProgressEntries.map(([itemId, progress]) =>
+      this._getLibraryItemDetails(itemId, progress).catch(error => {
+        if (this._isRecoverableError(error)) {
+          logger.debug(
+            'Recoverable error fetching mediaProgress item details',
+            {
+              itemId,
+              error: error.message,
+            },
+          );
+          return null;
+        }
+
+        logger.error('Critical error fetching mediaProgress item details', {
+          itemId,
+          error: error.message,
+        });
+        throw error;
+      }),
     );
 
     const itemDetails = (await Promise.all(detailPromises)).filter(Boolean);
@@ -1020,11 +1032,15 @@ export class AudiobookshelfClient {
       // Undefined uses the configured cap. Explicit null means no limit.
       const effectiveLimit = limit === undefined ? this.maxBooksToFetch : limit;
       const itemsPerPage = this.pageSize; // Use configurable page size
+      const requestPageSize =
+        effectiveLimit === null
+          ? itemsPerPage
+          : Math.min(itemsPerPage, effectiveLimit);
 
       while (true) {
         const response = await this._makeRequest(
           'GET',
-          `/api/libraries/${libraryId}/items?limit=${itemsPerPage}&page=${page}`,
+          `/api/libraries/${libraryId}/items?limit=${requestPageSize}&page=${page}`,
         );
 
         if (!response) {
@@ -1054,7 +1070,11 @@ export class AudiobookshelfClient {
           });
         }
 
-        allItems.push(...items);
+        const itemsToAdd =
+          effectiveLimit === null
+            ? items
+            : items.slice(0, effectiveLimit - allItems.length);
+        allItems.push(...itemsToAdd);
         logger.debug('Fetched library items page', {
           libraryId,
           page,
@@ -1065,7 +1085,7 @@ export class AudiobookshelfClient {
         // Check if we've reached the limit or end of data
         if (
           (effectiveLimit !== null && allItems.length >= effectiveLimit) ||
-          items.length < itemsPerPage
+          items.length < requestPageSize
         ) {
           break;
         }

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -30,12 +30,6 @@ export class SyncManager {
     this.taskQueue = new TaskQueue({ concurrency: workers });
     this.abortController = new AbortController();
 
-    // Increase max listeners for AbortSignal to handle parallel processing
-    // This prevents MaxListenersExceededWarning when processing many books
-    const maxBooks = this.globalConfig.max_books_to_fetch ?? 500;
-    const requiredListeners = Math.max(20, maxBooks + 10); // Buffer for safety
-    setMaxListeners(requiredListeners, this.abortController.signal);
-
     this.timezone = globalConfig.timezone || 'UTC';
 
     // Resolve library configuration (user-specific overrides global)
@@ -905,6 +899,14 @@ export class SyncManager {
   }
 
   async _syncBooksParallel(booksToProcess, result, sessionData) {
+    // p-queue attaches a temporary abort listener for each queued task. Size
+    // the signal for the actual batch rather than a configured fetch limit,
+    // which may differ from the number of books ultimately processed.
+    setMaxListeners(
+      Math.max(20, booksToProcess.length + 10),
+      this.abortController.signal,
+    );
+
     const promises = booksToProcess.map(book =>
       this.taskQueue.enqueue(
         async () => {

--- a/tests/audiobookshelf-media-progress.test.js
+++ b/tests/audiobookshelf-media-progress.test.js
@@ -160,4 +160,117 @@ describe('Audiobookshelf mediaProgress handling', () => {
       client.cleanup();
     }
   });
+
+  it('limits mediaProgress item detail fetches', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+      1,
+      5,
+      100,
+    );
+    const mediaProgress = Array.from({ length: 21 }, (_, index) =>
+      createMediaProgress(`book-${index}`),
+    );
+    let detailFetches = 0;
+
+    client._getCurrentUser = async () => ({ mediaProgress });
+    client.getLibraries = async () => [{ id: 'library', name: 'Library' }];
+    client._makeRequest = async (_method, endpoint) => {
+      if (endpoint === '/api/libraries/library/items?limit=1&page=0') {
+        return { total: 21 };
+      }
+
+      if (endpoint.startsWith('/api/items/')) {
+        detailFetches++;
+        return {
+          id: endpoint.replace('/api/items/', ''),
+          libraryId: 'library',
+          media: { metadata: { title: endpoint } },
+        };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    };
+
+    try {
+      const books = await client.getReadingProgress();
+
+      assert.equal(detailFetches, 5);
+      assert.equal(books.filter(book => !book._isMetadataOnly).length, 5);
+    } finally {
+      client.cleanup();
+    }
+  });
+
+  it('does not let a page exceed maxBooksToFetch', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+      1,
+      5,
+      100,
+    );
+    let requestedEndpoint;
+
+    client._makeRequest = async (_method, endpoint) => {
+      requestedEndpoint = endpoint;
+      return {
+        total: 21,
+        results: Array.from({ length: 21 }, (_, index) => ({
+          id: `book-${index}`,
+        })),
+      };
+    };
+
+    try {
+      const books = await client.getLibraryItems('library');
+
+      assert.equal(
+        requestedEndpoint,
+        '/api/libraries/library/items?limit=5&page=0',
+      );
+      assert.equal(books.length, 5);
+    } finally {
+      client.cleanup();
+    }
+  });
+
+  it('uses a stable page size while enforcing maxBooksToFetch', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+      1,
+      3,
+      2,
+    );
+    const requestedEndpoints = [];
+    const pages = [
+      [{ id: 'book-1' }, { id: 'book-2' }],
+      [{ id: 'book-3' }, { id: 'book-4' }],
+    ];
+
+    client._makeRequest = async (_method, endpoint) => {
+      requestedEndpoints.push(endpoint);
+      const page = Number(
+        new URL(`https://test.example${endpoint}`).searchParams.get('page'),
+      );
+      return { total: 4, results: pages[page] || [] };
+    };
+
+    try {
+      const books = await client.getLibraryItems('library');
+
+      assert.deepEqual(requestedEndpoints, [
+        '/api/libraries/library/items?limit=2&page=0',
+        '/api/libraries/library/items?limit=2&page=1',
+      ]);
+      assert.deepEqual(
+        books.map(book => book.id),
+        ['book-1', 'book-2', 'book-3'],
+      );
+    } finally {
+      client.cleanup();
+    }
+  });
 });

--- a/tests/task-queue-basic.test.js
+++ b/tests/task-queue-basic.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { getEventListeners, setMaxListeners } from 'node:events';
 import { describe, it } from 'node:test';
 
 import { TaskQueue } from '../src/utils/task-queue.js';
@@ -175,6 +176,22 @@ describe('TaskQueue (Basic)', () => {
       await assert.rejects(
         async () => await queue.enqueue(task, { signal: controller.signal }),
       );
+    });
+
+    it('removes abort listeners after tasks complete', async () => {
+      const queue = new TaskQueue({ concurrency: 3 });
+      const controller = new AbortController();
+      setMaxListeners(100, controller.signal);
+
+      await Promise.all(
+        Array.from({ length: 25 }, () =>
+          queue.enqueue(async () => 'result', {
+            signal: controller.signal,
+          }),
+        ),
+      );
+
+      assert.equal(getEventListeners(controller.signal, 'abort').length, 0);
     });
   });
 });

--- a/wiki/admin/Configuration-Reference.md
+++ b/wiki/admin/Configuration-Reference.md
@@ -373,6 +373,9 @@ global:
 - **Environment**: `SHELFBRIDGE_MAX_BOOKS_TO_FETCH=1000`
 - **Description**: Maximum number of books to fetch from Audiobookshelf
 - **Use Case**: Prevents memory issues on resource-constrained devices
+- **Behavior**: The limit is enforced for both paginated library results and
+  `/api/me` media-progress item detail lookups; a response page cannot cause
+  ShelfBridge to exceed the configured maximum
 
 #### `page_size`
 

--- a/wiki/technical/Pagination-System.md
+++ b/wiki/technical/Pagination-System.md
@@ -59,6 +59,10 @@ global:
    - No more items returned from API
    - Page returns fewer items than requested
 
+The same maximum is applied before ShelfBridge fetches item details for records
+returned by Audiobookshelf's `/api/me` media-progress data. This keeps the limit
+effective regardless of which Audiobookshelf progress endpoint is available.
+
 ## 📊 Performance Characteristics
 
 ### Memory Usage


### PR DESCRIPTION
## Summary

- upgrade p-queue so abort listeners are removed after queued tasks complete
- size the AbortSignal listener allowance from the actual processing batch
- enforce max_books_to_fetch for media-progress details and paginated library responses
- add regression tests for listener cleanup and strict fetch limits

## Verification

- npm run lint
- focused tests: 21 passed
- full Node 24 test suite: 506 passed
- git diff --check

Closes #199