### PR TITLE
fix: prioritize recently updated progress records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cron": "^3.5.0",
         "cronstrue": "^3.2.0",
         "inquirer": "^12.9.4",
-        "js-yaml": "5.0.0",
+        "js-yaml": "5.2.1",
         "luxon": "^3.7.1",
         "node-cron": "^4.2.1",
         "p-queue": "^9.3.1",
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2032,9 +2032,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.0.0.tgz",
-      "integrity": "sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cron": "^3.5.0",
     "cronstrue": "^3.2.0",
     "inquirer": "^12.9.4",
-    "js-yaml": "5.0.0",
+    "js-yaml": "5.2.1",
     "luxon": "^3.7.1",
     "node-cron": "^4.2.1",
     "p-queue": "^9.3.1",
@@ -87,6 +87,6 @@
     "color-convert": "2.0.1",
     "simple-swizzle": "0.2.4",
     "form-data": "4.0.6",
-    "js-yaml": "5.0.0"
+    "js-yaml": "5.2.1"
   }
 }

--- a/src/audiobookshelf-client.js
+++ b/src/audiobookshelf-client.js
@@ -664,16 +664,15 @@ export class AudiobookshelfClient {
     });
 
     const progressEntries = Array.from(progressByItemId.entries());
+    progressEntries.sort(
+      ([, firstProgress], [, secondProgress]) =>
+        (secondProgress.lastUpdate || 0) - (firstProgress.lastUpdate || 0),
+    );
+
     const cappedProgressEntries =
       this.maxBooksToFetch === null
         ? progressEntries
-        : progressEntries
-            .toSorted(
-              ([, firstProgress], [, secondProgress]) =>
-                (secondProgress.lastUpdate || 0) -
-                (firstProgress.lastUpdate || 0),
-            )
-            .slice(0, this.maxBooksToFetch);
+        : progressEntries.slice(0, this.maxBooksToFetch);
 
     if (cappedProgressEntries.length < progressEntries.length) {
       logger.debug('Limited mediaProgress item detail fetches', {

--- a/src/audiobookshelf-client.js
+++ b/src/audiobookshelf-client.js
@@ -667,7 +667,13 @@ export class AudiobookshelfClient {
     const cappedProgressEntries =
       this.maxBooksToFetch === null
         ? progressEntries
-        : progressEntries.slice(0, this.maxBooksToFetch);
+        : progressEntries
+            .toSorted(
+              ([, firstProgress], [, secondProgress]) =>
+                (secondProgress.lastUpdate || 0) -
+                (firstProgress.lastUpdate || 0),
+            )
+            .slice(0, this.maxBooksToFetch);
 
     if (cappedProgressEntries.length < progressEntries.length) {
       logger.debug('Limited mediaProgress item detail fetches', {

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,7 @@ export class Config {
 
     try {
       const configFile = fs.readFileSync(this.configPath, 'utf8');
-      const config = yaml.load(configFile) || {}; // Handle empty YAML files
+      const config = configFile.trim() ? yaml.load(configFile) || {} : {};
 
       this.globalConfig = config.global || {};
       this.users = config.users || [];

--- a/tests/audiobookshelf-media-progress.test.js
+++ b/tests/audiobookshelf-media-progress.test.js
@@ -300,6 +300,51 @@ describe('Audiobookshelf mediaProgress handling', () => {
     }
   });
 
+  it('prioritizes recently updated mediaProgress when detail fetches are limited', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+      1,
+      2,
+      100,
+    );
+    const mediaProgress = [
+      createMediaProgress('older-book', { lastUpdate: 1000 }),
+      createMediaProgress('oldest-book', { lastUpdate: 500 }),
+      createMediaProgress('newest-book', { lastUpdate: 3000 }),
+      createMediaProgress('newer-book', { lastUpdate: 2000 }),
+    ];
+    const fetchedItemIds = [];
+
+    client._getCurrentUser = async () => ({ mediaProgress });
+    client.getLibraries = async () => [{ id: 'library', name: 'Library' }];
+    client._makeRequest = async (_method, endpoint) => {
+      if (endpoint === '/api/libraries/library/items?limit=1&page=0') {
+        return { total: mediaProgress.length };
+      }
+
+      if (endpoint.startsWith('/api/items/')) {
+        const itemId = endpoint.replace('/api/items/', '');
+        fetchedItemIds.push(itemId);
+        return {
+          id: itemId,
+          libraryId: 'library',
+          media: { metadata: { title: itemId } },
+        };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    };
+
+    try {
+      await client.getReadingProgress();
+
+      assert.deepEqual(fetchedItemIds, ['newest-book', 'newer-book']);
+    } finally {
+      client.cleanup();
+    }
+  });
+
   it('does not let a page exceed maxBooksToFetch', async () => {
     const client = new AudiobookshelfClient(
       'https://test.example',

--- a/tests/audiobookshelf-media-progress.test.js
+++ b/tests/audiobookshelf-media-progress.test.js
@@ -345,6 +345,51 @@ describe('Audiobookshelf mediaProgress handling', () => {
     }
   });
 
+  it('prioritizes recently updated mediaProgress without a detail fetch limit', async () => {
+    const client = new AudiobookshelfClient(
+      'https://test.example',
+      'test-token',
+    );
+    const mediaProgress = [
+      createMediaProgress('older-book', { lastUpdate: 1000 }),
+      createMediaProgress('newest-book', { lastUpdate: 3000 }),
+      createMediaProgress('newer-book', { lastUpdate: 2000 }),
+    ];
+    const fetchedItemIds = [];
+
+    client._getCurrentUser = async () => ({ mediaProgress });
+    client.getLibraries = async () => [{ id: 'library', name: 'Library' }];
+    client._makeRequest = async (_method, endpoint) => {
+      if (endpoint === '/api/libraries/library/items?limit=1&page=0') {
+        return { total: mediaProgress.length };
+      }
+
+      if (endpoint.startsWith('/api/items/')) {
+        const itemId = endpoint.replace('/api/items/', '');
+        fetchedItemIds.push(itemId);
+        return {
+          id: itemId,
+          libraryId: 'library',
+          media: { metadata: { title: itemId } },
+        };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    };
+
+    try {
+      await client.getReadingProgress();
+
+      assert.deepEqual(fetchedItemIds, [
+        'newest-book',
+        'newer-book',
+        'older-book',
+      ]);
+    } finally {
+      client.cleanup();
+    }
+  });
+
   it('does not let a page exceed maxBooksToFetch', async () => {
     const client = new AudiobookshelfClient(
       'https://test.example',

--- a/wiki/admin/Configuration-Reference.md
+++ b/wiki/admin/Configuration-Reference.md
@@ -375,8 +375,8 @@ global:
 - **Use Case**: Prevents memory issues on resource-constrained devices
 - **Behavior**: The limit is enforced for both paginated library results and
   `/api/me` media-progress item detail lookups; a response page cannot cause
-  ShelfBridge to exceed the configured maximum. When media-progress details
-  are limited, the most recently updated records are fetched first.
+  ShelfBridge to exceed the configured maximum. Media-progress details are
+  fetched in most-recently-updated order, with the limit applied afterward.
 
 #### `page_size`
 

--- a/wiki/admin/Configuration-Reference.md
+++ b/wiki/admin/Configuration-Reference.md
@@ -375,7 +375,8 @@ global:
 - **Use Case**: Prevents memory issues on resource-constrained devices
 - **Behavior**: The limit is enforced for both paginated library results and
   `/api/me` media-progress item detail lookups; a response page cannot cause
-  ShelfBridge to exceed the configured maximum
+  ShelfBridge to exceed the configured maximum. When media-progress details
+  are limited, the most recently updated records are fetched first.
 
 #### `page_size`
 


### PR DESCRIPTION
## Problem

`max_books_to_fetch` previously selected records in the order returned by Audiobookshelf. That order is not guaranteed to reflect recent listening activity, so a low limit could repeatedly process the same completed books while never examining an actively read book.

## Changes

- deduplicate `/api/me` media-progress records by library item
- sort the deduplicated records in place by `lastUpdate`, newest first
- use that ordering for both capped and uncapped syncs
- apply `max_books_to_fetch` only after ordering, so the cap selects the most recently active books
- retain stable relative ordering for records with equal or missing timestamps
- document the media-progress ordering behavior
- add regression coverage for capped and uncapped selection

The ordering is performed client-side on the lightweight progress metadata already returned by `/api/me`. The in-place sort does not duplicate the array, does not expand the API response, and `max_books_to_fetch` continues to limit the more expensive `/api/items/{id}` detail requests.

## Dependency audit

The Code Quality workflow also exposed existing audit findings on `main`. This PR updates:

- `brace-expansion` from 1.1.14 to 1.1.16
- `js-yaml` from 5.0.0 to 5.2.1

`src/config.js` explicitly treats an empty config file as an empty object to preserve existing behavior with the updated `js-yaml`.

## Validation

- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `npm run lint`
- focused media-progress and YAML configuration tests — 28/28 passing
- Code Quality Checks — passed
- Node.js 22.x — passed
- Node.js 24.x — passed
- Docker Build Test — passed