### PR TITLE
fix: repair Hardcover null progress updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cron": "^3.5.0",
         "cronstrue": "^3.2.0",
         "inquirer": "^12.9.4",
-        "js-yaml": "5.2.1",
+        "js-yaml": "5.2.3",
         "luxon": "^3.7.1",
         "node-cron": "^4.2.1",
         "p-queue": "^9.3.1",
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2032,9 +2032,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",
@@ -2434,16 +2434,16 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cron": "^3.5.0",
     "cronstrue": "^3.2.0",
     "inquirer": "^12.9.4",
-    "js-yaml": "5.2.1",
+    "js-yaml": "5.2.3",
     "luxon": "^3.7.1",
     "node-cron": "^4.2.1",
     "p-queue": "^9.3.1",
@@ -87,6 +87,6 @@
     "color-convert": "2.0.1",
     "simple-swizzle": "0.2.4",
     "form-data": "4.0.6",
-    "js-yaml": "5.2.1"
+    "js-yaml": "5.2.3"
   }
 }

--- a/src/hardcover-client.js
+++ b/src/hardcover-client.js
@@ -329,6 +329,8 @@ export class HardcoverClient {
                         error
                         user_book_read {
                             id
+                            progress
+                            progress_pages
                             progress_seconds
                             edition_id
                             started_at
@@ -347,7 +349,9 @@ export class HardcoverClient {
                         error
                         user_book_read {
                             id
+                            progress
                             progress_pages
+                            progress_seconds
                             edition_id
                             started_at
 
@@ -375,12 +379,26 @@ export class HardcoverClient {
       );
       try {
         const result = await this._executeQuery(mutation, variables);
-        if (
-          result &&
-          result.update_user_book_read &&
-          result.update_user_book_read.user_book_read
-        ) {
-          const updatedRecord = result.update_user_book_read.user_book_read;
+        const updateResult = result?.update_user_book_read;
+        if (updateResult?.error) {
+          logger.error(
+            `Hardcover rejected progress update: ${updateResult.error}`,
+          );
+          return false;
+        }
+
+        if (updateResult?.user_book_read) {
+          const updatedRecord = updateResult.user_book_read;
+          if (
+            !this._isProgressWriteVerified(
+              updatedRecord,
+              currentProgress,
+              useSeconds,
+              progressPercentage,
+            )
+          ) {
+            return false;
+          }
           logger.debug(
             `Updated progress - start date now: ${updatedRecord.started_at}`,
           );
@@ -392,20 +410,6 @@ export class HardcoverClient {
               statusWasUpdated,
             },
           };
-        }
-        // Check for reading_format related errors in the response
-        if (
-          result &&
-          result.update_user_book_read &&
-          result.update_user_book_read.error
-        ) {
-          const errorMsg = result.update_user_book_read.error;
-          if (
-            errorMsg.toLowerCase().includes('reading_format') ||
-            errorMsg.toLowerCase().includes('format')
-          ) {
-            logger.error(`Reading format related error: ${errorMsg}`);
-          }
         }
         return false;
       } catch (error) {
@@ -440,6 +444,55 @@ export class HardcoverClient {
         },
       };
     }
+  }
+
+  _isProgressWriteVerified(
+    record,
+    expectedPosition,
+    useSeconds,
+    expectedPercentage = null,
+  ) {
+    const progressField = useSeconds ? 'progress_seconds' : 'progress_pages';
+    const returnedPosition = record?.[progressField];
+    const numericPosition = Number(returnedPosition);
+    const numericExpected = Number(expectedPosition);
+
+    if (
+      returnedPosition === null ||
+      returnedPosition === undefined ||
+      !Number.isFinite(numericPosition) ||
+      !Number.isFinite(numericExpected) ||
+      Math.abs(numericPosition - numericExpected) > 1
+    ) {
+      logger.error('Hardcover returned an unverified progress update', {
+        recordId: record?.id,
+        progressField,
+        expectedPosition,
+        returnedPosition,
+      });
+      return false;
+    }
+
+    if (
+      expectedPercentage !== null &&
+      Number(expectedPercentage) > 0 &&
+      Object.prototype.hasOwnProperty.call(record, 'progress')
+    ) {
+      const calculatedProgress = Number(record.progress);
+      if (!Number.isFinite(calculatedProgress) || calculatedProgress <= 0) {
+        logger.error(
+          'Hardcover did not calculate progress for the updated read',
+          {
+            recordId: record.id,
+            expectedPercentage,
+            returnedProgress: record.progress,
+          },
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -800,6 +853,8 @@ export class HardcoverClient {
                         started_at
                         finished_at
                         edition_id
+                        progress
+                        progress_pages
                         progress_seconds
 
                     }
@@ -820,6 +875,8 @@ export class HardcoverClient {
                         finished_at
                         edition_id
                         progress_pages
+                        progress_seconds
+                        progress
 
                     }
                 }
@@ -846,6 +903,11 @@ export class HardcoverClient {
         result.insert_user_book_read.user_book_read
       ) {
         const newRecord = result.insert_user_book_read.user_book_read;
+        if (
+          !this._isProgressWriteVerified(newRecord, currentProgress, useSeconds)
+        ) {
+          return null;
+        }
         logger.debug(
           `Created new progress record with start date: ${newRecord.started_at}`,
         );

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -6,6 +6,7 @@ import ProgressManager from './progress-manager.js';
 import {
   BookMatcher,
   extractAuthor,
+  extractAudioDurationFromAudiobookshelf,
   extractBookIdentifiers,
   extractTitle,
   getIsbnVariants,
@@ -721,6 +722,150 @@ export class SyncManager {
     }
   }
 
+  _getEditionProgressBasis(edition) {
+    if (!edition) return null;
+
+    const audioSeconds = Number(edition.audio_seconds);
+    const pages = Number(edition.pages);
+    const format = ProgressManager.getFormatFromEdition(edition);
+
+    if (
+      format === 'audiobook' &&
+      Number.isFinite(audioSeconds) &&
+      audioSeconds > 0
+    ) {
+      return { type: 'seconds', total: audioSeconds, useSeconds: true };
+    }
+
+    if (Number.isFinite(pages) && pages > 0) {
+      return { type: 'pages', total: pages, useSeconds: false };
+    }
+
+    if (Number.isFinite(audioSeconds) && audioSeconds > 0) {
+      return { type: 'seconds', total: audioSeconds, useSeconds: true };
+    }
+
+    return null;
+  }
+
+  _isEditionProgressCapable(edition) {
+    return this._getEditionProgressBasis(edition) !== null;
+  }
+
+  _getCachedEditionRepairState(editionId) {
+    if (!Array.isArray(this.hardcoverBooks)) {
+      return { requiresRepair: false, reason: null };
+    }
+
+    const userBook = this._findUserBookByEditionId(editionId);
+    if (!userBook) {
+      return {
+        requiresRepair: true,
+        reason:
+          'cached edition is not present in the current Hardcover library',
+      };
+    }
+
+    const edition = this._findEditionInUserBook(userBook, editionId);
+    if (!edition) {
+      return {
+        requiresRepair: true,
+        reason: 'cached edition details are unavailable',
+      };
+    }
+
+    if (!this._isEditionProgressCapable(edition)) {
+      return {
+        requiresRepair: true,
+        reason: 'cached edition has neither audiobook duration nor page count',
+      };
+    }
+
+    return { requiresRepair: false, reason: null };
+  }
+
+  _selectProgressCapableEdition(absBook, userBook, preferredEdition, title) {
+    if (this._isEditionProgressCapable(preferredEdition)) {
+      return {
+        ...preferredEdition,
+        format: this._mapHardcoverFormatToInternal(preferredEdition),
+      };
+    }
+
+    const editions = userBook?.book?.editions || [];
+    const sourceFormat = ProgressManager.getBookFormat(absBook);
+    const sourceDuration = extractAudioDurationFromAudiobookshelf(absBook);
+    const seenEditionIds = new Set();
+    const candidates = [];
+
+    for (const edition of [...editions, preferredEdition]) {
+      if (!edition || seenEditionIds.has(String(edition.id))) continue;
+      seenEditionIds.add(String(edition.id));
+
+      const basis = this._getEditionProgressBasis(edition);
+      if (!basis) continue;
+
+      const editionFormat = ProgressManager.getFormatFromEdition(edition);
+      const formatRank =
+        sourceFormat === 'audiobook'
+          ? basis.useSeconds
+            ? 0
+            : 1
+          : basis.useSeconds
+            ? 1
+            : 0;
+      const durationDifference =
+        basis.useSeconds && sourceDuration
+          ? Math.abs(basis.total - sourceDuration)
+          : Number.POSITIVE_INFINITY;
+
+      candidates.push({
+        edition,
+        basis,
+        editionFormat,
+        formatRank,
+        durationDifference,
+        popularity: Number(edition.users_count || edition.score || 0),
+      });
+    }
+
+    candidates.sort((left, right) => {
+      if (left.formatRank !== right.formatRank) {
+        return left.formatRank - right.formatRank;
+      }
+      if (left.durationDifference !== right.durationDifference) {
+        return left.durationDifference - right.durationDifference;
+      }
+      return right.popularity - left.popularity;
+    });
+
+    const replacement = candidates[0];
+    if (!replacement) {
+      logger.error(`No progress-capable Hardcover edition found for ${title}`, {
+        preferredEditionId: preferredEdition?.id,
+        preferredFormat: preferredEdition?.reading_format?.format,
+        preferredAudioSeconds: preferredEdition?.audio_seconds,
+        preferredPages: preferredEdition?.pages,
+        availableEditions: editions.length,
+      });
+      return null;
+    }
+
+    logger.warn(`Replacing unusable Hardcover edition for ${title}`, {
+      previousEditionId: preferredEdition?.id,
+      replacementEditionId: replacement.edition.id,
+      replacementFormat: replacement.editionFormat,
+      progressUnit: replacement.basis.type,
+      sourceDuration,
+      replacementTotal: replacement.basis.total,
+    });
+
+    return {
+      ...replacement.edition,
+      format: this._mapHardcoverFormatToInternal(replacement.edition),
+    };
+  }
+
   /**
    * Format timestamp for display using configured timezone
    * @param {string|number} timestamp - Timestamp value (ISO string or milliseconds)
@@ -1083,6 +1228,7 @@ export class SyncManager {
 
         let hasChanged = true; // Default to true (needs sync)
         let cacheFoundEarly = false;
+        let requiresProgressRepair = false;
 
         // Try each cache key to find existing progress data and cached match info
         let cachedMatchInfo = null;
@@ -1116,7 +1262,26 @@ export class SyncManager {
                 type,
               );
 
-              if (!progressChanged) {
+              const repairState = this._getCachedEditionRepairState(
+                cachedInfo.edition_id,
+              );
+
+              if (!progressChanged && repairState.requiresRepair) {
+                requiresProgressRepair = true;
+                hasChanged = true;
+                cacheFoundEarly = false;
+                logger.warn(
+                  `Cached progress for ${title} requires repair despite an unchanged percentage`,
+                  {
+                    cacheKey: key,
+                    cacheType: type,
+                    editionId: cachedInfo.edition_id,
+                    progress: validatedProgress,
+                    reason: repairState.reason,
+                  },
+                );
+                break;
+              } else if (!progressChanged) {
                 hasChanged = false;
                 cacheFoundEarly = true;
                 logger.debug(
@@ -1152,7 +1317,7 @@ export class SyncManager {
 
         // ALWAYS check title/author cache for comprehensive optimization
         // This handles books that gained identifiers after being originally matched by title/author
-        if (hasChanged) {
+        if (hasChanged && !requiresProgressRepair) {
           // Try MULTIPLE title/author cache patterns for backward compatibility with existing cache entries
           const titleAuthorPatterns = [
             // 1. Current standard pattern (TitleAuthorMatcher)
@@ -3021,7 +3186,7 @@ export class SyncManager {
         absBook,
         `book "${title}" completion check`,
         {},
-        edition, // Pass edition for consistent format detection
+        selectedEdition, // Use the progress-capable edition selected for this sync
       );
 
       if (isComplete) {
@@ -3133,7 +3298,7 @@ export class SyncManager {
           title: title,
           author: author,
           userBookId: userBook.id,
-          editionId: edition.id,
+          editionId: edition?.id,
         },
       );
     }
@@ -3149,25 +3314,34 @@ export class SyncManager {
       );
     }
 
-    if (cachedEditionId) {
-      // Find the cached edition in the book's editions
-      const book = userBook.book;
-      if (book && book.editions) {
-        const cachedEdition = book.editions.find(e => e.id === cachedEditionId);
-        if (cachedEdition) {
-          // Apply format extraction consistently
-          return {
-            ...cachedEdition,
-            format: this._mapHardcoverFormatToInternal(cachedEdition),
-          };
-        }
-      }
-    }
+    const cachedEdition = cachedEditionId
+      ? userBook.book?.editions?.find(
+          candidate => String(candidate.id) === String(cachedEditionId),
+        )
+      : null;
+    const preferredEdition = cachedEdition || edition;
+    const selectedEdition = this._selectProgressCapableEdition(
+      absBook,
+      userBook,
+      preferredEdition,
+      title,
+    );
 
-    // Use the matched edition and cache it in transaction
-    if (edition) {
-      // Use author from metadata (already extracted)
+    if (!selectedEdition) return null;
 
+    const editionChanged =
+      !cachedEditionId ||
+      String(selectedEdition.id) !== String(cachedEditionId);
+    const shouldDeferReplacementCache = cachedEditionId && editionChanged;
+
+    if (shouldDeferReplacementCache) {
+      logger.debug(`Deferring replacement edition cache update for ${title}`, {
+        cachedEditionId,
+        replacementEditionId: selectedEdition.id,
+        reason:
+          'Replacement will be cached only after Hardcover confirms progress',
+      });
+    } else if (editionChanged) {
       try {
         // Only store edition mapping if we have a valid identifier
         if (identifierValue && identifierType) {
@@ -3178,7 +3352,7 @@ export class SyncManager {
                   this.userId,
                   identifierValue,
                   title,
-                  edition.id,
+                  selectedEdition.id,
                   identifierType,
                   author,
                 ),
@@ -3191,7 +3365,7 @@ export class SyncManager {
           logger.debug(`Successfully cached edition mapping for ${title}`, {
             identifier: identifierValue,
             identifierType: identifierType,
-            editionId: edition.id,
+            editionId: selectedEdition.id,
           });
         } else {
           logger.warn(
@@ -3202,8 +3376,6 @@ export class SyncManager {
             },
           );
         }
-
-        return edition;
       } catch (error) {
         logger.error(
           `Failed to cache edition mapping for ${title}: ${error.message}`,
@@ -3213,12 +3385,10 @@ export class SyncManager {
             stack: error.stack,
           },
         );
-        // Still return the edition even if caching fails
-        return edition;
       }
     }
 
-    return null;
+    return selectedEdition;
   }
 
   async _handleCompletionStatus(
@@ -3405,7 +3575,7 @@ export class SyncManager {
       progress: progressPercent,
       userBookId: userBookId,
       editionId: edition.id,
-      format: edition.audio_seconds ? 'audiobook' : 'text',
+      format: ProgressManager.getFormatFromEdition(edition),
     });
 
     if (this.dryRun) {
@@ -3416,37 +3586,35 @@ export class SyncManager {
     }
 
     try {
-      // Calculate current progress value
-      let currentProgress = 0;
-      let useSeconds = false;
-
-      if (edition.audio_seconds) {
-        currentProgress = ProgressManager.calculateCurrentPosition(
-          progressPercent,
-          edition.audio_seconds,
-          {
-            type: 'seconds',
-            context: `book "${title}" audio progress calculation`,
-          },
-        );
-        useSeconds = true;
-      } else if (edition.pages) {
-        currentProgress = ProgressManager.calculateCurrentPosition(
-          progressPercent,
-          edition.pages,
-          {
-            type: 'pages',
-            context: `book "${title}" page progress calculation`,
-          },
-        );
+      const progressBasis = this._getEditionProgressBasis(edition);
+      if (!progressBasis) {
+        const reason =
+          'Selected Hardcover edition has neither audiobook duration nor page count';
+        logger.error(`Cannot update progress for ${title}: ${reason}`, {
+          editionId: edition.id,
+          readingFormat: edition.reading_format?.format,
+          audioSeconds: edition.audio_seconds,
+          pages: edition.pages,
+        });
+        return { status: 'error', reason, title };
       }
+
+      const useSeconds = progressBasis.useSeconds;
+      const currentProgress = ProgressManager.calculateCurrentPosition(
+        progressPercent,
+        progressBasis.total,
+        {
+          type: progressBasis.type,
+          context: `book "${title}" ${progressBasis.type} progress calculation`,
+        },
+      );
 
       logger.debug(
         `📊 Calculated ${title} progress: ${progressPercent.toFixed(1)}%`,
         {
           [useSeconds ? 'progress' : 'progress']: useSeconds
-            ? `${formatDurationForLogging(currentProgress)} of ${formatDurationForLogging(edition.audio_seconds)}`
-            : `page ${currentProgress} of ${edition.pages}`,
+            ? `${formatDurationForLogging(currentProgress)} of ${formatDurationForLogging(progressBasis.total)}`
+            : `page ${currentProgress} of ${progressBasis.total}`,
           format: edition.format || (useSeconds ? 'audiobook' : 'book'),
         },
       );

--- a/tests/hardcover-null-progress-repair.test.js
+++ b/tests/hardcover-null-progress-repair.test.js
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+import { HardcoverClient } from '../src/hardcover-client.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+const clients = [];
+
+function createManager() {
+  const manager = Object.create(SyncManager.prototype);
+  manager.userId = 'test-user';
+  manager.globalConfig = {};
+  manager.dryRun = false;
+  return manager;
+}
+
+function createClient() {
+  const client = new HardcoverClient('test-token');
+  clients.push(client);
+  return client;
+}
+
+afterEach(() => {
+  while (clients.length > 0) {
+    clients.pop().cleanup();
+  }
+});
+
+describe('Hardcover null progress repair', () => {
+  it('treats a Listened edition without duration or pages as unusable', () => {
+    const manager = createManager();
+    const edition = {
+      id: 31673834,
+      reading_format: { format: 'Listened' },
+      audio_seconds: null,
+      pages: null,
+    };
+
+    assert.equal(manager._getEditionProgressBasis(edition), null);
+    assert.equal(manager._isEditionProgressCapable(edition), false);
+  });
+
+  it('selects the closest usable audiobook edition from the same book', () => {
+    const manager = createManager();
+    const unusableEdition = {
+      id: 31673834,
+      reading_format: { format: 'Listened' },
+      audio_seconds: null,
+      pages: null,
+    };
+    const closestAudiobook = {
+      id: 400,
+      reading_format: { format: 'Listened' },
+      audio_seconds: 28800,
+      pages: null,
+    };
+    const longerAudiobook = {
+      id: 401,
+      reading_format: { format: 'Listened' },
+      audio_seconds: 36000,
+      pages: null,
+    };
+    const textEdition = {
+      id: 402,
+      reading_format: { format: 'Read' },
+      audio_seconds: null,
+      pages: 288,
+    };
+    const userBook = {
+      book: {
+        editions: [
+          unusableEdition,
+          longerAudiobook,
+          textEdition,
+          closestAudiobook,
+        ],
+      },
+    };
+    const absBook = { media: { duration: 29000 } };
+
+    const selected = manager._selectProgressCapableEdition(
+      absBook,
+      userBook,
+      unusableEdition,
+      'Test Audiobook',
+    );
+
+    assert.equal(selected.id, closestAudiobook.id);
+    assert.equal(selected.format, 'audiobook');
+  });
+
+  it('marks unchanged cached progress for repair when its edition is unusable', () => {
+    const manager = createManager();
+    const edition = {
+      id: 31673834,
+      reading_format: { format: 'Listened' },
+      audio_seconds: null,
+      pages: null,
+    };
+    manager.hardcoverBooks = [
+      {
+        id: 16884926,
+        book: { editions: [edition] },
+      },
+    ];
+
+    const repairState = manager._getCachedEditionRepairState(edition.id);
+
+    assert.equal(repairState.requiresRepair, true);
+    assert.match(
+      repairState.reason,
+      /neither audiobook duration nor page count/,
+    );
+  });
+
+  it('defers caching a replacement edition until progress is confirmed', async () => {
+    const manager = createManager();
+    const unusableEdition = {
+      id: 31673834,
+      asin: 'B09WPZ3K2B',
+      reading_format: { format: 'Listened' },
+      audio_seconds: null,
+      pages: null,
+    };
+    const replacementEdition = {
+      id: 400,
+      reading_format: { format: 'Listened' },
+      audio_seconds: 28800,
+      pages: null,
+    };
+    const executeTransaction = mock.fn(async () => {});
+    manager.cache = {
+      getEditionForBook: mock.fn(async () => unusableEdition.id),
+      executeTransaction,
+    };
+    const userBook = {
+      id: 16884926,
+      book: { editions: [unusableEdition, replacementEdition] },
+    };
+
+    const selected = await manager._selectEditionWithCache(
+      {
+        media: {
+          duration: 28800,
+          metadata: { asin: 'B09WPZ3K2B' },
+        },
+      },
+      { userBook, edition: unusableEdition },
+      'Test Audiobook',
+      'Test Author',
+    );
+
+    assert.equal(selected.id, replacementEdition.id);
+    assert.equal(executeTransaction.mock.calls.length, 0);
+  });
+
+  it('does not call Hardcover when no edition can represent progress', async () => {
+    const manager = createManager();
+    const updateReadingProgress = mock.fn(async () => ({ id: 1 }));
+    manager.hardcover = { updateReadingProgress };
+    const edition = {
+      id: 31673834,
+      reading_format: { format: 'Listened' },
+      audio_seconds: null,
+      pages: null,
+    };
+
+    const result = await manager._handleProgressStatus(
+      16884926,
+      edition,
+      'Test Audiobook',
+      66.6,
+      {},
+      'Test Author',
+    );
+
+    assert.equal(result.status, 'error');
+    assert.match(result.reason, /neither audiobook duration nor page count/);
+    assert.equal(updateReadingProgress.mock.calls.length, 0);
+  });
+
+  it('rejects a Hardcover response whose requested progress field is null', async () => {
+    const client = createClient();
+    client.getBookCurrentProgress = mock.fn(async () => ({
+      has_progress: true,
+      latest_read: { id: 6130328 },
+      user_book: { id: 16884926, status_id: 2 },
+    }));
+    client._shouldCreateNewReadingSession = mock.fn(() => ({
+      createNew: false,
+      isRegression: false,
+    }));
+    client._executeQuery = mock.fn(async () => ({
+      update_user_book_read: {
+        error: null,
+        user_book_read: {
+          id: 6130328,
+          progress: null,
+          progress_pages: null,
+          edition_id: 31673834,
+        },
+      },
+    }));
+
+    const result = await client.updateReadingProgress(
+      16884926,
+      0,
+      66.6,
+      31673834,
+      false,
+      '2026-07-29',
+    );
+
+    assert.equal(result, false);
+  });
+
+  it('accepts a verified seconds-based Hardcover response', async () => {
+    const client = createClient();
+    client.getBookCurrentProgress = mock.fn(async () => ({
+      has_progress: true,
+      latest_read: { id: 6130328 },
+      user_book: { id: 16884926, status_id: 2 },
+    }));
+    client._shouldCreateNewReadingSession = mock.fn(() => ({
+      createNew: false,
+      isRegression: false,
+    }));
+    client._executeQuery = mock.fn(async () => ({
+      update_user_book_read: {
+        error: null,
+        user_book_read: {
+          id: 6130328,
+          progress: 66.6,
+          progress_pages: null,
+          progress_seconds: 19181,
+          edition_id: 400,
+        },
+      },
+    }));
+
+    const result = await client.updateReadingProgress(
+      16884926,
+      19181,
+      66.6,
+      400,
+      true,
+      '2026-07-29',
+    );
+
+    assert.equal(result.id, 6130328);
+    assert.equal(result.progress_seconds, 19181);
+  });
+});


### PR DESCRIPTION
Repairs progress syncs when the matched Hardcover edition cannot represent progress because both audio_seconds and pages are null. ShelfBridge now selects a progress-capable edition from the same book, retries unchanged poisoned cache entries, verifies Hardcover returned the requested progress field before caching success, and refuses unrepresentable writes. Regression coverage includes the original null-progress response and seconds-based fallback. Tests: 527 passed, 0 failed.