### PR TITLE
fix(matching): harden audiobook matching and dry-run sync behavior

### DIFF
--- a/src/book-cache.js
+++ b/src/book-cache.js
@@ -529,7 +529,7 @@ export class BookCache {
     let originalBusyTimeout;
     try {
       // Get current busy timeout and set a new one
-      originalBusyTimeout = this.db.pragma('busy_timeout', true);
+      originalBusyTimeout = this.db.pragma('busy_timeout', { simple: true });
       this.db.pragma(`busy_timeout = ${timeout}`);
     } catch (error) {
       logger.debug(`Could not set database timeout: ${error.message}`);

--- a/src/display/SyncResultFormatter.js
+++ b/src/display/SyncResultFormatter.js
@@ -179,29 +179,29 @@ export class SyncResultFormatter {
     ];
 
     const successfulStatuses = new Set(['synced', 'completed', 'auto_added']);
-    const detailedSuccessfulUpdates =
+    const detailedSuccessfulBooks =
       Array.isArray(result.book_details) && result.book_details.length > 0
         ? result.book_details.filter(book =>
             successfulStatuses.has(book.status),
           ).length
         : null;
-    const totalApiCalls =
-      detailedSuccessfulUpdates ??
+    const successfulBooks =
+      detailedSuccessfulBooks ??
       result.books_synced + result.books_completed + result.books_auto_added;
-    const skippedCalls = result.books_skipped;
+    const skippedBooks = result.books_skipped;
 
     if (isDryRun) {
       // In dry-run mode, show what would happen
-      rightColumn.push(`├─ ${totalApiCalls} would be updated`);
+      rightColumn.push(`├─ ${successfulBooks} would be updated`);
       rightColumn.push(`├─ 0 API calls made (dry run)`);
       rightColumn.push(`├─ ${result.errors.length} would fail`);
-      rightColumn.push(`└─ ${skippedCalls} skipped (no changes)`);
+      rightColumn.push(`└─ ${skippedBooks} skipped (no changes)`);
     } else {
       // Normal mode, show actual results
-      rightColumn.push(`├─ ${totalApiCalls} API calls made`);
-      rightColumn.push(`├─ ${totalApiCalls} successful`);
+      const bookLabel = successfulBooks === 1 ? 'book' : 'books';
+      rightColumn.push(`├─ ${successfulBooks} ${bookLabel} updated`);
       rightColumn.push(`├─ ${result.errors.length} failed`);
-      rightColumn.push(`└─ ${skippedCalls} skipped (no changes)`);
+      rightColumn.push(`└─ ${skippedBooks} skipped (no changes)`);
     }
 
     return rightColumn;

--- a/src/display/SyncResultFormatter.js
+++ b/src/display/SyncResultFormatter.js
@@ -178,7 +178,15 @@ export class SyncResultFormatter {
       isDryRun ? '🌐 Hardcover Updates (DRY RUN)' : '🌐 Hardcover Updates',
     ];
 
+    const successfulStatuses = new Set(['synced', 'completed', 'auto_added']);
+    const detailedSuccessfulUpdates =
+      Array.isArray(result.book_details) && result.book_details.length > 0
+        ? result.book_details.filter(book =>
+            successfulStatuses.has(book.status),
+          ).length
+        : null;
     const totalApiCalls =
+      detailedSuccessfulUpdates ??
       result.books_synced + result.books_completed + result.books_auto_added;
     const skippedCalls = result.books_skipped;
 

--- a/src/hardcover-client.js
+++ b/src/hardcover-client.js
@@ -1637,6 +1637,7 @@ export class HardcoverClient {
             pages
             audio_seconds
             score
+            users_count
             contributions {
               author {
                 id

--- a/src/main.js
+++ b/src/main.js
@@ -568,7 +568,7 @@ async function processStartupSessions(users, globalConfig) {
       });
 
       // Initialize cache to check for active sessions
-      const cache = new BookCache(`data/.book_cache_${user.id}.db`);
+      const cache = new BookCache();
       await cache.init();
 
       // Get all active sessions for this user

--- a/src/matching/book-matcher.js
+++ b/src/matching/book-matcher.js
@@ -659,6 +659,13 @@ export class BookMatcher {
     );
   }
 
+  getTitleAuthorMatchFailure(absBook) {
+    const titleAuthorStrategy = this.strategies.find(
+      strategy => strategy.getName?.() === 'title_author',
+    );
+    return titleAuthorStrategy?.getMatchFailure?.(absBook) || null;
+  }
+
   /**
    * Get matching statistics
    * @returns {Object} - Statistics about matching strategies

--- a/src/matching/book-matcher.js
+++ b/src/matching/book-matcher.js
@@ -15,6 +15,8 @@ import { TitleAuthorMatcher } from './strategies/title-author-matcher.js';
 import {
   extractTitle,
   extractAuthor,
+  extractNarrator,
+  extractAudioDurationFromAudiobookshelf,
   detectUserBookFormat,
 } from './utils/audiobookshelf-extractor.js';
 import { getIsbnVariants, normalizeAsin } from './utils/text-matching.js';
@@ -359,6 +361,18 @@ export class BookMatcher {
               sourceFormat,
               matchType,
             );
+          } else if (
+            strategy.getTier() <= 2 &&
+            match._isSearchResult
+          ) {
+            const sourceFormat = detectUserBookFormat(absBook);
+            const matchType = match._matchType || 'identifier_search_result';
+            match = await this._enhanceIdentifierSearchResultEdition(
+              match,
+              absBook,
+              sourceFormat,
+              matchType,
+            );
           }
 
           logger.debug(
@@ -576,6 +590,107 @@ export class BookMatcher {
       _upgradeReason: hasLength
         ? 'format_match_improvement'
         : 'length_data_enrichment',
+      _scoreImprovement: result.improvement,
+    };
+  }
+
+  /**
+   * Treat a new identifier result as work-level evidence when its exact
+   * edition has the wrong format or lacks format-appropriate length data.
+   * This keeps exact, usable audiobook matches untouched while allowing a
+   * print/ebook ISBN to resolve to the best audiobook edition on that work.
+   */
+  async _enhanceIdentifierSearchResultEdition(
+    match,
+    absBook,
+    sourceFormat = null,
+    matchType = 'identifier_search_result',
+  ) {
+    const currentEdition = match?.edition;
+    const bookId = match?.book?.id || currentEdition?.book?.id;
+    if (!currentEdition || !bookId) {
+      return match;
+    }
+
+    const currentFormat = this.formatMapper
+      ? this.formatMapper(currentEdition)
+      : currentEdition.format || currentEdition.reading_format?.format;
+    const hasExpectedLength =
+      sourceFormat === 'audiobook'
+        ? Number(currentEdition.audio_seconds) > 0
+        : Number(currentEdition.pages) > 0;
+
+    if (currentFormat === sourceFormat && hasExpectedLength) {
+      return match;
+    }
+
+    let book;
+    try {
+      book = await this.hardcoverClient.getBookDetailsWithEditions(bookId);
+    } catch (error) {
+      logger.warn('Failed to fetch editions for identifier search result', {
+        bookId,
+        editionId: currentEdition.id,
+        error: error.message,
+      });
+      return match;
+    }
+
+    if (!book?.editions?.length) {
+      return match;
+    }
+
+    const { selectBestEdition, PROFILES } =
+      await import('./utils/unified-edition-scorer.js');
+    const identifierProfile = {
+      ...PROFILES.TITLE_AUTHOR,
+      name: 'IDENTIFIER_SEARCH_RESULT',
+      minImprovement: 5,
+    };
+    const result = selectBestEdition(book.editions, {
+      sourceFormat,
+      sourceDuration: extractAudioDurationFromAudiobookshelf(absBook),
+      sourceNarrator: extractNarrator(absBook),
+      profile: identifierProfile,
+      currentEdition,
+      formatMapper: this.formatMapper,
+    });
+
+    if (!result?.edition || !result.shouldUpgrade) {
+      return match;
+    }
+
+    const selectedEdition = {
+      ...result.edition,
+      format:
+        result.edition.format ||
+        result.edition.reading_format?.format ||
+        result.edition.physical_format ||
+        'unknown',
+      book: currentEdition.book || {
+        id: book.id || bookId,
+        title: book.title,
+        contributions: book.contributions || [],
+      },
+    };
+
+    logger.info('Upgraded identifier search result to ABS-aware edition', {
+      bookId,
+      originalEditionId: currentEdition.id,
+      selectedEditionId: selectedEdition.id,
+      sourceFormat,
+      selectedFormat: selectedEdition.format,
+      scoreImprovement: result.improvement.toFixed(1),
+    });
+
+    return {
+      ...match,
+      edition: selectedEdition,
+      book: match.book || selectedEdition.book,
+      _originalEditionId: currentEdition.id,
+      _matchType: `${matchType}_cross_edition_enriched`,
+      _editionUpgraded: true,
+      _upgradeReason: 'identifier_work_edition_selection',
       _scoreImprovement: result.improvement,
     };
   }

--- a/src/matching/index.js
+++ b/src/matching/index.js
@@ -22,6 +22,7 @@ export {
   convertIsbn10To13,
   convertIsbn13To10,
   getIsbnVariants,
+  getIsbn10FromNumericAsin,
   normalizeAsin,
   normalizeTitle,
   normalizeAuthor,

--- a/src/matching/scoring/book-identification-scorer.js
+++ b/src/matching/scoring/book-identification-scorer.js
@@ -184,6 +184,20 @@ export function calculateBookIdentificationScore(
     };
   }
 
+  const targetTitleNumbers = extractTitleNumbers(targetTitle);
+  const resultTitleNumbers = extractTitleNumbers(resultTitle);
+  if (
+    targetTitleNumbers.length > 0 &&
+    resultTitleNumbers.length > 0 &&
+    targetTitleNumbers.join(',') !== resultTitleNumbers.join(',')
+  ) {
+    score -= 100;
+    breakdown.titleNumberMismatchPenalty = {
+      score: -100,
+      reason: `Conflicting title numbers (${targetTitleNumbers.join(', ')} vs ${resultTitleNumbers.join(', ')}) - likely different works`,
+    };
+  }
+
   // ============================================================================
   // SCORE CAPPING AND CONFIDENCE DETERMINATION
   // ============================================================================
@@ -216,6 +230,10 @@ export function calculateBookIdentificationScore(
     isBookMatch,
     coreFactorsScore: titleScore * 0.35 + authorScore * 0.25, // Title + Author only
   };
+}
+
+function extractTitleNumbers(title) {
+  return normalizeTitle(title).match(/\b\d+\b/g) || [];
 }
 
 /**

--- a/src/matching/scoring/book-identification-scorer.js
+++ b/src/matching/scoring/book-identification-scorer.js
@@ -23,6 +23,7 @@ import {
   extractSeries as extractSeriesFromSearchResult,
   extractPublicationYear as extractPublicationYearFromSearchResult,
 } from '../utils/hardcover-extractor.js';
+import { evaluateStrongBookIdentity } from '../utils/book-identity-evidence.js';
 
 /**
  * Calculate book identification confidence score
@@ -70,6 +71,11 @@ export function calculateBookIdentificationScore(
 
   // Extract activity data (still relevant for book disambiguation)
   const resultActivity = extractActivityFromSearchResult(searchResult);
+  const strongIdentityEvidence = evaluateStrongBookIdentity(
+    searchResult,
+    targetTitle,
+    targetAuthor,
+  );
 
   // ============================================================================
   // BOOK IDENTIFICATION FACTORS (Edition-agnostic)
@@ -228,6 +234,7 @@ export function calculateBookIdentificationScore(
     breakdown,
     confidence,
     isBookMatch,
+    strongIdentityEvidence,
     coreFactorsScore: titleScore * 0.35 + authorScore * 0.25, // Title + Author only
   };
 }

--- a/src/matching/scoring/book-identification-scorer.js
+++ b/src/matching/scoring/book-identification-scorer.js
@@ -190,18 +190,26 @@ export function calculateBookIdentificationScore(
     };
   }
 
-  const targetTitleNumbers = extractTitleNumbers(targetTitle);
-  const resultTitleNumbers = extractTitleNumbers(resultTitle);
-  if (
-    targetTitleNumbers.length > 0 &&
-    resultTitleNumbers.length > 0 &&
-    targetTitleNumbers.join(',') !== resultTitleNumbers.join(',')
-  ) {
+  if (strongIdentityEvidence.explicitWorkPartConflict) {
     score -= 100;
     breakdown.titleNumberMismatchPenalty = {
       score: -100,
-      reason: `Conflicting title numbers (${targetTitleNumbers.join(', ')} vs ${resultTitleNumbers.join(', ')}) - likely different works`,
+      reason: 'Conflicting explicit volume or part numbers - different works',
     };
+  } else {
+    const targetTitleNumbers = extractTitleNumbers(targetTitle);
+    const resultTitleNumbers = extractTitleNumbers(resultTitle);
+    if (
+      targetTitleNumbers.length > 0 &&
+      resultTitleNumbers.length > 0 &&
+      targetTitleNumbers.join(',') !== resultTitleNumbers.join(',')
+    ) {
+      score -= 100;
+      breakdown.titleNumberMismatchPenalty = {
+        score: -100,
+        reason: `Conflicting title numbers (${targetTitleNumbers.join(', ')} vs ${resultTitleNumbers.join(', ')}) - likely different works`,
+      };
+    }
   }
 
   // ============================================================================

--- a/src/matching/strategies/asin-matcher.js
+++ b/src/matching/strategies/asin-matcher.js
@@ -8,6 +8,7 @@
 import logger from '../../logger.js';
 import { extractTitle } from '../utils/audiobookshelf-extractor.js';
 import { isIdentifierTitlePlausible } from '../utils/identifier-title-validator.js';
+import { getIsbn10FromNumericAsin } from '../utils/text-matching.js';
 
 /**
  * ASIN Matching Strategy - Tier 1
@@ -50,12 +51,30 @@ export class AsinMatcher {
 
         try {
           // Search Hardcover's global database for this ASIN
-          const searchResults = await this.hardcoverClient.searchBooksByAsin(
+          let searchMethod = 'asin';
+          let searchResults = await this.hardcoverClient.searchBooksByAsin(
             identifiers.asin,
           );
           logger.debug(
             `ASIN search returned ${searchResults.length} results for ${identifiers.asin}`,
           );
+
+          const numericAsinIsbn = getIsbn10FromNumericAsin(
+            identifiers.asin,
+          );
+          if (
+            searchResults.length === 0 &&
+            numericAsinIsbn &&
+            this.hardcoverClient.searchBooksByIsbn
+          ) {
+            logger.debug(
+              `Retrying numeric ASIN ${identifiers.asin} as ISBN-10`,
+            );
+            searchResults = await this.hardcoverClient.searchBooksByIsbn(
+              numericAsinIsbn,
+            );
+            searchMethod = 'isbn';
+          }
 
           const plausibleResults = searchResults.filter(result => {
             const hardcoverTitle = result.book?.title;
@@ -115,7 +134,7 @@ export class AsinMatcher {
                   return {
                     userBook: existingUserBook,
                     edition: userEdition,
-                    _matchType: 'asin_cross_edition',
+                    _matchType: `${searchMethod}_cross_edition`,
                     _tier: 1,
                     _needsScoring: false,
                   };
@@ -138,7 +157,7 @@ export class AsinMatcher {
             return {
               userBook: null,
               edition: firstResult,
-              _matchType: 'asin_search_result',
+              _matchType: `${searchMethod}_search_result`,
               _tier: 1,
               _needsScoring: false,
               _needsBookIdLookup: true, // Book ID needs to be looked up from edition

--- a/src/matching/strategies/asin-matcher.js
+++ b/src/matching/strategies/asin-matcher.js
@@ -7,6 +7,7 @@
 
 import logger from '../../logger.js';
 import { extractTitle } from '../utils/audiobookshelf-extractor.js';
+import { isIdentifierTitlePlausible } from '../utils/identifier-title-validator.js';
 
 /**
  * ASIN Matching Strategy - Tier 1
@@ -56,9 +57,22 @@ export class AsinMatcher {
             `ASIN search returned ${searchResults.length} results for ${identifiers.asin}`,
           );
 
-          if (searchResults.length > 0) {
+          const plausibleResults = searchResults.filter(result => {
+            const hardcoverTitle = result.book?.title;
+            const plausible = isIdentifierTitlePlausible(title, hardcoverTitle);
+            if (!plausible) {
+              logger.warn(`Rejected ASIN result with conflicting title`, {
+                asin: identifiers.asin,
+                sourceTitle: title,
+                hardcoverTitle,
+              });
+            }
+            return plausible;
+          });
+
+          if (plausibleResults.length > 0) {
             // Check if we have any edition of the same book
-            for (const result of searchResults) {
+            for (const result of plausibleResults) {
               const bookId = result.book?.id;
               if (bookId) {
                 logger.debug(
@@ -110,7 +124,7 @@ export class AsinMatcher {
             }
 
             // If we found ASIN results but user doesn't have the book, return for auto-add consideration
-            const firstResult = searchResults[0];
+            const firstResult = plausibleResults[0];
             logger.debug(
               `📍 ASIN match found in Hardcover database but not in user library - returning for auto-add consideration`,
               {

--- a/src/matching/strategies/isbn-matcher.js
+++ b/src/matching/strategies/isbn-matcher.js
@@ -7,6 +7,7 @@
 
 import logger from '../../logger.js';
 import { extractTitle } from '../utils/audiobookshelf-extractor.js';
+import { isIdentifierTitlePlausible } from '../utils/identifier-title-validator.js';
 import { getIsbnVariants } from '../utils/text-matching.js';
 
 /**
@@ -61,9 +62,22 @@ export class IsbnMatcher {
             `ISBN search returned ${searchResults.length} results for ${identifiers.isbn}`,
           );
 
-          if (searchResults.length > 0) {
+          const plausibleResults = searchResults.filter(result => {
+            const hardcoverTitle = result.book?.title;
+            const plausible = isIdentifierTitlePlausible(title, hardcoverTitle);
+            if (!plausible) {
+              logger.warn(`Rejected ISBN result with conflicting title`, {
+                isbn: identifiers.isbn,
+                sourceTitle: title,
+                hardcoverTitle,
+              });
+            }
+            return plausible;
+          });
+
+          if (plausibleResults.length > 0) {
             // Check if we have any edition of the same book
-            for (const result of searchResults) {
+            for (const result of plausibleResults) {
               const bookId = result.book?.id;
               if (bookId) {
                 logger.debug(
@@ -100,7 +114,7 @@ export class IsbnMatcher {
             }
 
             // If we found ISBN results but user doesn't have the book, return for auto-add consideration
-            const firstResult = searchResults[0];
+            const firstResult = plausibleResults[0];
             logger.debug(
               `📍 ISBN match found in Hardcover database but not in user library - returning for auto-add consideration`,
               {

--- a/src/matching/strategies/title-author-matcher.js
+++ b/src/matching/strategies/title-author-matcher.js
@@ -30,6 +30,18 @@ export class TitleAuthorMatcher {
     this.hardcoverClient = hardcoverClient;
     this.cache = cache;
     this.config = config;
+    this.matchFailures = new WeakMap();
+  }
+
+  _setMatchFailure(absBook, failure) {
+    if (absBook && typeof absBook === 'object') {
+      this.matchFailures.set(absBook, failure);
+    }
+  }
+
+  getMatchFailure(absBook) {
+    if (!absBook || typeof absBook !== 'object') return null;
+    return this.matchFailures.get(absBook) || null;
   }
 
   /**
@@ -46,6 +58,10 @@ export class TitleAuthorMatcher {
     findUserBookByEditionId = null,
     findUserBookByBookId = null,
   ) {
+    if (absBook && typeof absBook === 'object') {
+      this.matchFailures.delete(absBook);
+    }
+
     // Store the user library lookup functions for use in this matching session
     this._findUserBookByEditionIdImpl = findUserBookByEditionId;
     this._findUserBookByBookIdImpl = findUserBookByBookId;
@@ -186,6 +202,10 @@ export class TitleAuthorMatcher {
       });
 
       if (searchResults.length === 0) {
+        this._setMatchFailure(absBook, {
+          outcome: 'NOT_FOUND',
+          reason: 'No title/author search results',
+        });
         logger.debug(
           `No search results found for "${title}" in Hardcover database`,
           {
@@ -411,6 +431,12 @@ export class TitleAuthorMatcher {
         }
 
         if (!selectedEditionResult) {
+          this._setMatchFailure(absBook, {
+            outcome: 'MATCH_REJECTED',
+            reason: 'No compatible edition found for identified book',
+            candidateTitle: bestBookMatch.title,
+            candidateBookId: bestBookMatch.id,
+          });
           logger.warn(
             `No suitable edition found for "${title}" despite successful book identification`,
           );
@@ -561,6 +587,18 @@ export class TitleAuthorMatcher {
           outcome: 'MATCH_REJECTED',
         });
 
+        this._setMatchFailure(absBook, {
+          outcome: 'MATCH_REJECTED',
+          reason: bestScoredBook
+            ? bestScoredBook._bookIdentificationScore.isBookMatch
+              ? `Best candidate scored ${bestScore.toFixed(1)}% below the configured threshold`
+              : 'Best candidate failed guarded book identity checks'
+            : 'No viable title/author candidate',
+          candidateTitle: bestScoredBook?.title || null,
+          candidateBookId: bestScoredBook?.id || null,
+          candidateScore: bestScoredBook ? bestScore : null,
+        });
+
         // Move detailed candidate info to debug level to avoid confusion
         if (bestScoredBook) {
           logger.debug(`Rejected candidate details for "${title}"`, {
@@ -587,6 +625,10 @@ export class TitleAuthorMatcher {
         return null;
       }
     } catch (error) {
+      this._setMatchFailure(absBook, {
+        outcome: 'SEARCH_ERROR',
+        reason: error.message,
+      });
       logger.warn(
         `Title/author search failed for "${title}": ${error.message}`,
         {

--- a/src/matching/strategies/title-author-matcher.js
+++ b/src/matching/strategies/title-author-matcher.js
@@ -27,6 +27,7 @@ import {
   selectBestEdition,
 } from '../utils/unified-edition-scorer.js';
 import { normalizeTitle } from '../utils/text-matching.js';
+import { normalizeWorkTitle } from '../utils/book-title-identity.js';
 
 function getEditionFormat(edition) {
   return edition?.reading_format?.format || edition?.physical_format || null;
@@ -43,6 +44,24 @@ function getPreferredFormatCandidates(editions, userFormat) {
   });
 
   return listenedEditions.length > 0 ? listenedEditions : editions;
+}
+
+function hasPreferredFormat(editions, userFormat) {
+  if (userFormat !== 'audiobook') return true;
+
+  return editions.some(edition => {
+    const format = getEditionFormat(edition)?.toLowerCase();
+    return format === 'listened' || format === 'audiobook';
+  });
+}
+
+function isAcceptableBookMatch(result, confidenceThreshold) {
+  const identificationScore = result?._bookIdentificationScore;
+  return (
+    (identificationScore?.isBookMatch &&
+      identificationScore.totalScore >= confidenceThreshold * 100) ||
+    identificationScore?.strongIdentityEvidence?.matches === true
+  );
 }
 
 /**
@@ -174,12 +193,122 @@ export class TitleAuthorMatcher {
         },
       });
 
-      const searchResults = await this.hardcoverClient.searchBooksForMatching(
+      let searchResults = await this.hardcoverClient.searchBooksForMatching(
         normalizedSearchTitle, // Use normalized title for API search
         author,
         narrator,
         maxResults,
       );
+
+      const initialCandidateCount = searchResults.length;
+      const prefetchedBookDetails = new Map();
+      const preliminaryScoredResults = searchResults
+        .map(result => {
+          try {
+            return {
+              ...result,
+              _bookIdentificationScore: calculateBookIdentificationScore(
+                result,
+                title,
+                author,
+                absBook,
+              ),
+            };
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean)
+        .sort(
+          (a, b) =>
+            b._bookIdentificationScore.totalScore -
+            a._bookIdentificationScore.totalScore,
+        );
+      const preliminaryBookMatch = preliminaryScoredResults.find(result =>
+        isAcceptableBookMatch(result, confidenceThreshold),
+      );
+
+      let canonicalExpansionReason = null;
+      if (searchResults.length > 0 && !preliminaryBookMatch) {
+        canonicalExpansionReason = 'no acceptable combined-search candidate';
+      } else if (preliminaryBookMatch && userFormat === 'audiobook') {
+        let preliminaryBookWithEditions = preliminaryBookMatch;
+        if (!preliminaryBookWithEditions.editions?.length) {
+          try {
+            preliminaryBookWithEditions =
+              await this.hardcoverClient.getBookDetailsWithEditions(
+                preliminaryBookMatch.id,
+              );
+            if (preliminaryBookWithEditions) {
+              prefetchedBookDetails.set(
+                String(preliminaryBookMatch.id),
+                preliminaryBookWithEditions,
+              );
+            }
+          } catch (error) {
+            logger.warn(
+              `Failed to preflight editions for book ID ${preliminaryBookMatch.id}:`,
+              error.message,
+            );
+          }
+        }
+
+        if (
+          !hasPreferredFormat(
+            preliminaryBookWithEditions?.editions || [],
+            userFormat,
+          )
+        ) {
+          canonicalExpansionReason =
+            'accepted candidate has no preferred-format edition';
+        }
+      }
+
+      const canonicalSearchTitle = normalizeWorkTitle(title);
+      const initialSearchUsedTitleOnly = searchResults.some(result =>
+        String(result?._searchMetadata?.searchStrategy || '').startsWith(
+          'title_only',
+        ),
+      );
+      const canExpandCanonicalCandidates =
+        canonicalExpansionReason &&
+        canonicalSearchTitle &&
+        (canonicalSearchTitle !== normalizedSearchTitle ||
+          (searchResults.length > 0 &&
+            author &&
+            !initialSearchUsedTitleOnly));
+
+      if (canExpandCanonicalCandidates) {
+        logger.debug(`Expanding canonical candidates for "${title}"`, {
+          reason: canonicalExpansionReason,
+          originalSearchTitle: normalizedSearchTitle,
+          canonicalSearchTitle,
+        });
+
+        const canonicalResults =
+          await this.hardcoverClient.searchBooksForMatching(
+            canonicalSearchTitle,
+            null,
+            narrator,
+            maxResults,
+          );
+        const candidatesByBookId = new Map(
+          searchResults.map(result => [String(result.id), result]),
+        );
+        for (const result of canonicalResults) {
+          const bookId = String(result.id);
+          if (!candidatesByBookId.has(bookId)) {
+            candidatesByBookId.set(bookId, result);
+          }
+        }
+        searchResults = [...candidatesByBookId.values()];
+
+        logger.debug(`Canonical candidate expansion completed for "${title}"`, {
+          reason: canonicalExpansionReason,
+          addedCandidates: searchResults.length - initialCandidateCount,
+          totalCandidates: searchResults.length,
+        });
+      }
 
       logger.debug(`Title/author search results for "${title}"`, {
         resultCount: searchResults.length,
@@ -382,14 +511,9 @@ export class TitleAuthorMatcher {
       // title/author evidence to recover exact works hidden by source subtitles
       // or missing Hardcover author metadata.
       const bestScoredBook = bookScoredResults[0];
-      const bestBookMatch = bookScoredResults.find(result => {
-        const identificationScore = result._bookIdentificationScore;
-        return (
-          (identificationScore.isBookMatch &&
-            identificationScore.totalScore >= confidenceThreshold * 100) ||
-          identificationScore.strongIdentityEvidence?.matches === true
-        );
-      });
+      const bestBookMatch = bookScoredResults.find(result =>
+        isAcceptableBookMatch(result, confidenceThreshold),
+      );
 
       if (bestBookMatch) {
         if (
@@ -416,7 +540,8 @@ export class TitleAuthorMatcher {
 
         let selectedEditionResult = null;
         let finalMatch = null;
-        let bookWithEditions = bestBookMatch;
+        let bookWithEditions =
+          prefetchedBookDetails.get(String(bestBookMatch.id)) || bestBookMatch;
 
         if (!bookWithEditions.editions?.length) {
           logger.debug(`Fetching editions for book ID ${bestBookMatch.id}`);

--- a/src/matching/strategies/title-author-matcher.js
+++ b/src/matching/strategies/title-author-matcher.js
@@ -107,13 +107,16 @@ export class TitleAuthorMatcher {
       );
 
       // Extract source book metadata for logging
-      const { extractSeries, extractPublicationYear } =
-        await import('../utils/audiobookshelf-extractor.js');
+      const { extractSeries, extractPublicationYear } = await import(
+        '../utils/audiobookshelf-extractor.js'
+      );
       const sourceSeries = extractSeries(absBook);
       const sourceYear = extractPublicationYear(absBook);
 
       // Normalize title for Hardcover API search to fix issues like "(Unabridged)" suffix breaking search
-      const normalizedSearchTitle = normalizeTitle(title);
+      const normalizedSearchTitle = normalizeTitle(title, {
+        normalizeNumbers: false,
+      });
 
       logger.debug(`Title/author search initiated for "${title}"`, {
         searchTitle: title,

--- a/src/matching/strategies/title-author-matcher.js
+++ b/src/matching/strategies/title-author-matcher.js
@@ -14,12 +14,36 @@ import {
   extractTitle,
   extractAuthor,
   extractNarrator,
+  extractAudioDurationFromAudiobookshelf,
   detectUserBookFormat,
 } from '../utils/audiobookshelf-extractor.js';
-import { extractAuthorFromSearchResult } from '../utils/hardcover-extractor.js';
+import {
+  extractAuthorFromSearchResult,
+  extractNarratorFromSearchResult,
+} from '../utils/hardcover-extractor.js';
 import { calculateBookIdentificationScore } from '../scoring/book-identification-scorer.js';
-import { selectBestEdition } from '../edition-selector.js';
+import {
+  PROFILES,
+  selectBestEdition,
+} from '../utils/unified-edition-scorer.js';
 import { normalizeTitle } from '../utils/text-matching.js';
+
+function getEditionFormat(edition) {
+  return edition?.reading_format?.format || edition?.physical_format || null;
+}
+
+function getPreferredFormatCandidates(editions, userFormat) {
+  if (userFormat !== 'audiobook') {
+    return editions;
+  }
+
+  const listenedEditions = editions.filter(edition => {
+    const format = getEditionFormat(edition)?.toLowerCase();
+    return format === 'listened' || format === 'audiobook';
+  });
+
+  return listenedEditions.length > 0 ? listenedEditions : editions;
+}
 
 /**
  * Title/Author Matching Strategy - Tier 3
@@ -392,41 +416,69 @@ export class TitleAuthorMatcher {
 
         let selectedEditionResult = null;
         let finalMatch = null;
+        let bookWithEditions = bestBookMatch;
 
-        // Check if we already have editions data in the search result
-        if (bestBookMatch.editions && bestBookMatch.editions.length > 0) {
-          // Use the edition selector to pick the best edition
-          selectedEditionResult = selectBestEdition(
-            bestBookMatch,
-            absBook,
-            userFormat,
-          );
-        } else {
-          // Need to fetch editions from the book ID
+        if (!bookWithEditions.editions?.length) {
           logger.debug(`Fetching editions for book ID ${bestBookMatch.id}`);
           try {
-            const editionData =
-              await this.hardcoverClient.getPreferredEditionFromBookId(
+            bookWithEditions =
+              await this.hardcoverClient.getBookDetailsWithEditions(
                 bestBookMatch.id,
-                userFormat,
               );
-
-            if (editionData) {
-              selectedEditionResult = {
-                bookId: editionData.bookId,
-                title: editionData.title,
-                edition: editionData.edition,
-                selectionReason: {
-                  automatic: `Preferred ${userFormat} edition from book ID`,
-                },
-                alternativeEditions: [],
-              };
-            }
           } catch (error) {
             logger.warn(
               `Failed to fetch editions for book ID ${bestBookMatch.id}:`,
               error.message,
             );
+          }
+        }
+
+        if (bookWithEditions?.editions?.length) {
+          const editionCandidates = getPreferredFormatCandidates(
+            bookWithEditions.editions,
+            userFormat,
+          );
+
+          if (
+            userFormat === 'audiobook' &&
+            editionCandidates.length === bookWithEditions.editions.length &&
+            !editionCandidates.some(edition => {
+              const format = getEditionFormat(edition)?.toLowerCase();
+              return format === 'listened' || format === 'audiobook';
+            })
+          ) {
+            logger.warn(
+              `No Listened edition available for "${title}"; using the best edition on the identified book`,
+              {
+                bookId: bestBookMatch.id,
+                availableFormats: bookWithEditions.editions.map(
+                  getEditionFormat,
+                ),
+              },
+            );
+          }
+
+          const editionSelection = selectBestEdition(editionCandidates, {
+            sourceFormat: userFormat,
+            sourceDuration:
+              extractAudioDurationFromAudiobookshelf(absBook),
+            sourceNarrator: narrator,
+            profile: PROFILES.TITLE_AUTHOR,
+            formatMapper: getEditionFormat,
+          });
+
+          if (editionSelection) {
+            selectedEditionResult = {
+              bookId: bookWithEditions.id || bestBookMatch.id,
+              title: bookWithEditions.title || bestBookMatch.title,
+              edition: editionSelection.edition,
+              score: editionSelection.score,
+              narratorName: extractNarratorFromSearchResult(
+                editionSelection.edition,
+              ),
+              selectionReason: editionSelection.breakdown,
+              alternativeEditions: editionSelection.alternatives,
+            };
           }
         }
 

--- a/src/matching/strategies/title-author-matcher.js
+++ b/src/matching/strategies/title-author-matcher.js
@@ -282,6 +282,9 @@ export class TitleAuthorMatcher {
           passesThreshold:
             result._bookIdentificationScore.totalScore >=
             confidenceThreshold * 100,
+          strongIdentityMatch:
+            result._bookIdentificationScore.strongIdentityEvidence?.matches ||
+            false,
           breakdown: {
             title: {
               score: `${result._bookIdentificationScore.breakdown.title?.score?.toFixed(1) || 0}%`,
@@ -331,15 +334,34 @@ export class TitleAuthorMatcher {
         })),
       });
 
-      // Find best book match above identification threshold
-      const bestBookMatch = bookScoredResults[0];
+      // Keep the configured fuzzy threshold unchanged, but allow deterministic
+      // title/author evidence to recover exact works hidden by source subtitles
+      // or missing Hardcover author metadata.
+      const bestScoredBook = bookScoredResults[0];
+      const bestBookMatch = bookScoredResults.find(result => {
+        const identificationScore = result._bookIdentificationScore;
+        return (
+          (identificationScore.isBookMatch &&
+            identificationScore.totalScore >= confidenceThreshold * 100) ||
+          identificationScore.strongIdentityEvidence?.matches === true
+        );
+      });
 
-      if (
-        bestBookMatch &&
-        bestBookMatch._bookIdentificationScore.isBookMatch &&
-        bestBookMatch._bookIdentificationScore.totalScore >=
+      if (bestBookMatch) {
+        if (
+          bestBookMatch._bookIdentificationScore.totalScore <
           confidenceThreshold * 100
-      ) {
+        ) {
+          logger.info(`Accepted strong title/author identity for "${title}"`, {
+            hardcoverTitle: bestBookMatch.title,
+            score: `${bestBookMatch._bookIdentificationScore.totalScore.toFixed(1)}%`,
+            threshold: `${(confidenceThreshold * 100).toFixed(1)}%`,
+            reason:
+              bestBookMatch._bookIdentificationScore.strongIdentityEvidence
+                ?.reason,
+          });
+        }
+
         // ====================================================================
         // STAGE 2: EDITION SELECTION
         // ====================================================================
@@ -520,8 +542,8 @@ export class TitleAuthorMatcher {
 
         return finalMatch;
       } else {
-        const bestScore = bestBookMatch
-          ? bestBookMatch._bookIdentificationScore.totalScore
+        const bestScore = bestScoredBook
+          ? bestScoredBook._bookIdentificationScore.totalScore
           : 0;
 
         // Log the rejection decision clearly - no match was made
@@ -530,9 +552,9 @@ export class TitleAuthorMatcher {
           searchedAuthor: author || 'N/A',
           threshold: `${(confidenceThreshold * 100).toFixed(1)}%`,
           candidatesEvaluated: bookScoredResults.length,
-          bestScore: bestBookMatch ? `${bestScore.toFixed(1)}%` : 'N/A',
-          reason: bestBookMatch
-            ? bestBookMatch._bookIdentificationScore.isBookMatch
+          bestScore: bestScoredBook ? `${bestScore.toFixed(1)}%` : 'N/A',
+          reason: bestScoredBook
+            ? bestScoredBook._bookIdentificationScore.isBookMatch
               ? `Best candidate scored ${bestScore.toFixed(1)}% which is below ${(confidenceThreshold * 100).toFixed(1)}% threshold`
               : `Best candidate failed book identification criteria`
             : 'No viable candidates found',
@@ -540,17 +562,20 @@ export class TitleAuthorMatcher {
         });
 
         // Move detailed candidate info to debug level to avoid confusion
-        if (bestBookMatch) {
+        if (bestScoredBook) {
           logger.debug(`Rejected candidate details for "${title}"`, {
             rejectedCandidate: {
-              title: bestBookMatch.title,
+              title: bestScoredBook.title,
               author:
-                bestBookMatch.contributions
+                bestScoredBook.contributions
                   ?.map(c => c.author?.name)
                   .join(', ') || 'N/A',
               score: `${bestScore.toFixed(1)}%`,
-              confidence: bestBookMatch._bookIdentificationScore.confidence,
-              isBookMatch: bestBookMatch._bookIdentificationScore.isBookMatch,
+              confidence: bestScoredBook._bookIdentificationScore.confidence,
+              isBookMatch: bestScoredBook._bookIdentificationScore.isBookMatch,
+              strongIdentityEvidence:
+                bestScoredBook._bookIdentificationScore
+                  .strongIdentityEvidence,
             },
             suggestion:
               bestScore > 45 && bestScore < confidenceThreshold * 100

--- a/src/matching/utils/audiobookshelf-extractor.js
+++ b/src/matching/utils/audiobookshelf-extractor.js
@@ -511,6 +511,21 @@ export function extractAudioDurationFromAudiobookshelf(bookData) {
         return bookData.media[field];
       }
     }
+
+    // Standard (non-expanded) Audiobookshelf item responses omit
+    // media.duration but retain duration on each audio file.
+    if (Array.isArray(bookData.media.audioFiles)) {
+      const audioFileDuration = bookData.media.audioFiles.reduce(
+        (total, audioFile) => {
+          const duration = Number(audioFile?.duration);
+          return Number.isFinite(duration) && duration > 0
+            ? total + duration
+            : total;
+        },
+        0,
+      );
+      if (audioFileDuration > 0) return audioFileDuration;
+    }
   }
 
   // Check metadata object

--- a/src/matching/utils/book-identity-evidence.js
+++ b/src/matching/utils/book-identity-evidence.js
@@ -1,0 +1,101 @@
+import { normalizeAuthor } from './text-matching.js';
+import {
+  isCollectionTitle,
+  normalizeIdentityTitle,
+  normalizeWorkTitle,
+} from './book-title-identity.js';
+
+function getCandidateAuthorNames(searchResult) {
+  const contributions = [
+    ...(searchResult?.contributions || []),
+    ...(searchResult?.book?.contributions || []),
+  ];
+  const contributionNames = contributions
+    .map(contribution =>
+      contribution?.person?.name || contribution?.author?.name,
+    )
+    .filter(Boolean);
+
+  if (contributionNames.length > 0) return contributionNames;
+  if (Array.isArray(searchResult?.author_names)) {
+    return searchResult.author_names.filter(Boolean);
+  }
+  return searchResult?.author ? [searchResult.author] : [];
+}
+
+function hasAuthorOverlap(targetAuthor, candidateAuthors) {
+  const normalizedTarget = normalizeAuthor(targetAuthor || '');
+  if (!normalizedTarget) return false;
+
+  return candidateAuthors.some(candidateAuthor => {
+    const normalizedCandidate = normalizeAuthor(candidateAuthor);
+    if (normalizedCandidate.length < 4) return false;
+    return (
+      normalizedTarget.includes(normalizedCandidate) ||
+      normalizedCandidate.includes(normalizedTarget)
+    );
+  });
+}
+
+/**
+ * Identify deterministic title/author evidence that is safe to use alongside
+ * the configured fuzzy score. This does not lower the score threshold: it only
+ * handles exact work titles obscured by source subtitles or missing Hardcover
+ * author metadata.
+ */
+export function evaluateStrongBookIdentity(
+  searchResult,
+  targetTitle,
+  targetAuthor,
+) {
+  const candidateTitle = searchResult?.title || '';
+  const sourceTitle = normalizeIdentityTitle(targetTitle);
+  const candidateIdentityTitle = normalizeIdentityTitle(candidateTitle);
+  const sourceWorkTitle = normalizeWorkTitle(targetTitle);
+
+  const fullTitleMatch =
+    !!sourceTitle && sourceTitle === candidateIdentityTitle;
+  const canonicalTitleMatch =
+    !!sourceWorkTitle && sourceWorkTitle === candidateIdentityTitle;
+  const titleMatch = fullTitleMatch || canonicalTitleMatch;
+  const collectionConflict =
+    isCollectionTitle(candidateTitle) && !isCollectionTitle(targetTitle);
+
+  const candidateAuthors = getCandidateAuthorNames(searchResult);
+  const authorOverlap = hasAuthorOverlap(targetAuthor, candidateAuthors);
+  const candidateAuthorMissing = candidateAuthors.length === 0;
+  const titleWords = candidateIdentityTitle.split(/\s+/).filter(Boolean);
+  const distinctiveExactTitle =
+    fullTitleMatch &&
+    candidateIdentityTitle.length >= 15 &&
+    titleWords.length >= 3;
+
+  const matches =
+    titleMatch &&
+    !collectionConflict &&
+    (authorOverlap || (candidateAuthorMissing && distinctiveExactTitle));
+
+  let reason = 'insufficient deterministic evidence';
+  if (collectionConflict) {
+    reason = 'candidate is a collection but source is a single work';
+  } else if (!titleMatch) {
+    reason = 'candidate is neither the exact nor canonical source title';
+  } else if (authorOverlap) {
+    reason = fullTitleMatch
+      ? 'exact title with overlapping author'
+      : 'canonical source title with overlapping author';
+  } else if (candidateAuthorMissing && distinctiveExactTitle) {
+    reason = 'distinctive exact title with missing candidate author metadata';
+  } else {
+    reason = 'title evidence lacks author support';
+  }
+
+  return {
+    matches,
+    reason,
+    fullTitleMatch,
+    canonicalTitleMatch,
+    authorOverlap,
+    candidateAuthorMissing,
+  };
+}

--- a/src/matching/utils/book-identity-evidence.js
+++ b/src/matching/utils/book-identity-evidence.js
@@ -1,5 +1,6 @@
 import { normalizeAuthor } from './text-matching.js';
 import {
+  hasConflictingExplicitWorkParts,
   isCanonicalTitleReductionSafe,
   isCollectionTitle,
   normalizeIdentityTitle,
@@ -63,6 +64,10 @@ export function evaluateStrongBookIdentity(
   const titleMatch = fullTitleMatch || safeCanonicalTitleMatch;
   const collectionConflict =
     isCollectionTitle(candidateTitle) && !isCollectionTitle(targetTitle);
+  const explicitWorkPartConflict = hasConflictingExplicitWorkParts(
+    targetTitle,
+    candidateTitle,
+  );
 
   const candidateAuthors = getCandidateAuthorNames(searchResult);
   const authorOverlap = hasAuthorOverlap(targetAuthor, candidateAuthors);
@@ -76,10 +81,13 @@ export function evaluateStrongBookIdentity(
   const matches =
     titleMatch &&
     !collectionConflict &&
+    !explicitWorkPartConflict &&
     (authorOverlap || (candidateAuthorMissing && distinctiveExactTitle));
 
   let reason = 'insufficient deterministic evidence';
-  if (collectionConflict) {
+  if (explicitWorkPartConflict) {
+    reason = 'source and candidate have conflicting volume or part numbers';
+  } else if (collectionConflict) {
     reason = 'candidate is a collection but source is a single work';
   } else if (!titleMatch) {
     reason = canonicalTitleMatch
@@ -101,6 +109,7 @@ export function evaluateStrongBookIdentity(
     fullTitleMatch,
     canonicalTitleMatch,
     safeCanonicalTitleMatch,
+    explicitWorkPartConflict,
     authorOverlap,
     candidateAuthorMissing,
   };

--- a/src/matching/utils/book-identity-evidence.js
+++ b/src/matching/utils/book-identity-evidence.js
@@ -1,5 +1,6 @@
 import { normalizeAuthor } from './text-matching.js';
 import {
+  isCanonicalTitleReductionSafe,
   isCollectionTitle,
   normalizeIdentityTitle,
   normalizeWorkTitle,
@@ -57,7 +58,9 @@ export function evaluateStrongBookIdentity(
     !!sourceTitle && sourceTitle === candidateIdentityTitle;
   const canonicalTitleMatch =
     !!sourceWorkTitle && sourceWorkTitle === candidateIdentityTitle;
-  const titleMatch = fullTitleMatch || canonicalTitleMatch;
+  const safeCanonicalTitleMatch =
+    canonicalTitleMatch && isCanonicalTitleReductionSafe(targetTitle);
+  const titleMatch = fullTitleMatch || safeCanonicalTitleMatch;
   const collectionConflict =
     isCollectionTitle(candidateTitle) && !isCollectionTitle(targetTitle);
 
@@ -79,7 +82,9 @@ export function evaluateStrongBookIdentity(
   if (collectionConflict) {
     reason = 'candidate is a collection but source is a single work';
   } else if (!titleMatch) {
-    reason = 'candidate is neither the exact nor canonical source title';
+    reason = canonicalTitleMatch
+      ? 'canonical title reduction discarded an unverified work suffix'
+      : 'candidate is neither the exact nor canonical source title';
   } else if (authorOverlap) {
     reason = fullTitleMatch
       ? 'exact title with overlapping author'
@@ -95,6 +100,7 @@ export function evaluateStrongBookIdentity(
     reason,
     fullTitleMatch,
     canonicalTitleMatch,
+    safeCanonicalTitleMatch,
     authorOverlap,
     candidateAuthorMissing,
   };

--- a/src/matching/utils/book-title-identity.js
+++ b/src/matching/utils/book-title-identity.js
@@ -8,6 +8,8 @@ const SAFE_CANONICAL_SUFFIX_PATTERN =
 const SPLIT_AUDIO_PART_PATTERN = /[[(]\s*\d+\s+of\s+\d+\s*[\])]/i;
 const AUDIOBOOK_ANNOTATION_TEST_PATTERN =
   /[[(]\s*(?:abridged|audio\s+drama|audio\s+edition|audiobook|dramatized\s+adaptation|full\s+cast(?:\s+production)?|graphic\s*audio|unabridged)\s*[\])]/i;
+const EXPLICIT_WORK_PART_PATTERN =
+  /(?:\b(?:vol(?:ume)?|bk|book|pt|part)\b\.?\s*|#\s*)([a-z]+|\d+(?:\.\d+)?)/i;
 
 export const COLLECTION_TITLE_PATTERN =
   /\b(?:box(?:ed)?\s+set|collection(?:\s+set)?|omnibus|bundle|(?:two|three|four|five|six|seven|eight|nine|\d+)\s+books?)\b/i;
@@ -23,6 +25,25 @@ export function normalizeIdentityTitle(title) {
 export function normalizeWorkTitle(title) {
   const withoutAnnotations = stripAudiobookAnnotations(title);
   return normalizeTitle(withoutAnnotations.split(/[-:–—]/, 1)[0]);
+}
+
+function extractExplicitWorkPartNumber(title) {
+  const value = String(title || '').match(EXPLICIT_WORK_PART_PATTERN)?.[1];
+  if (!value) return null;
+  if (/^\d+(?:\.\d+)?$/.test(value)) return Number(value);
+
+  const normalized = normalizeTitle(value);
+  return /^\d+$/.test(normalized) ? Number(normalized) : null;
+}
+
+export function hasConflictingExplicitWorkParts(sourceTitle, candidateTitle) {
+  const sourcePart = extractExplicitWorkPartNumber(sourceTitle);
+  const candidatePart = extractExplicitWorkPartNumber(candidateTitle);
+  return (
+    sourcePart !== null &&
+    candidatePart !== null &&
+    sourcePart !== candidatePart
+  );
 }
 
 export function isCanonicalTitleReductionSafe(title) {

--- a/src/matching/utils/book-title-identity.js
+++ b/src/matching/utils/book-title-identity.js
@@ -1,0 +1,24 @@
+import { normalizeTitle } from './text-matching.js';
+
+const AUDIOBOOK_ANNOTATION_PATTERN =
+  /\s*[[(]\s*(?:abridged|audio\s+drama|audio\s+edition|audiobook|dramatized\s+adaptation|full\s+cast(?:\s+production)?|graphic\s*audio|unabridged)\s*[\])]/gi;
+
+export const COLLECTION_TITLE_PATTERN =
+  /\b(?:box(?:ed)?\s+set|collection(?:\s+set)?|omnibus|bundle|(?:two|three|four|five|six|seven|eight|nine|\d+)\s+books?)\b/i;
+
+export function stripAudiobookAnnotations(title) {
+  return String(title || '').replace(AUDIOBOOK_ANNOTATION_PATTERN, ' ').trim();
+}
+
+export function normalizeIdentityTitle(title) {
+  return normalizeTitle(stripAudiobookAnnotations(title));
+}
+
+export function normalizeWorkTitle(title) {
+  const withoutAnnotations = stripAudiobookAnnotations(title);
+  return normalizeTitle(withoutAnnotations.split(/[:–—]/, 1)[0]);
+}
+
+export function isCollectionTitle(title) {
+  return COLLECTION_TITLE_PATTERN.test(String(title || ''));
+}

--- a/src/matching/utils/book-title-identity.js
+++ b/src/matching/utils/book-title-identity.js
@@ -16,7 +16,7 @@ export function normalizeIdentityTitle(title) {
 
 export function normalizeWorkTitle(title) {
   const withoutAnnotations = stripAudiobookAnnotations(title);
-  return normalizeTitle(withoutAnnotations.split(/[:–—]/, 1)[0]);
+  return normalizeTitle(withoutAnnotations.split(/[-:–—]/, 1)[0]);
 }
 
 export function isCollectionTitle(title) {

--- a/src/matching/utils/book-title-identity.js
+++ b/src/matching/utils/book-title-identity.js
@@ -3,6 +3,12 @@ import { normalizeTitle } from './text-matching.js';
 const AUDIOBOOK_ANNOTATION_PATTERN =
   /\s*[[(]\s*(?:abridged|audio\s+drama|audio\s+edition|audiobook|dramatized\s+adaptation|full\s+cast(?:\s+production)?|graphic\s*audio|unabridged)\s*[\])]/gi;
 
+const SAFE_CANONICAL_SUFFIX_PATTERN =
+  /(?:\b(?:anniversary|special|revised|updated|expanded)\s+edition\b|\b(?:archive|chronicles|cycle|prequel|quartet|saga|series|trilogy)\b|^(?:a|an)\s+.+\b(?:adventure|novel|story)\b)/i;
+const SPLIT_AUDIO_PART_PATTERN = /[[(]\s*\d+\s+of\s+\d+\s*[\])]/i;
+const AUDIOBOOK_ANNOTATION_TEST_PATTERN =
+  /[[(]\s*(?:abridged|audio\s+drama|audio\s+edition|audiobook|dramatized\s+adaptation|full\s+cast(?:\s+production)?|graphic\s*audio|unabridged)\s*[\])]/i;
+
 export const COLLECTION_TITLE_PATTERN =
   /\b(?:box(?:ed)?\s+set|collection(?:\s+set)?|omnibus|bundle|(?:two|three|four|five|six|seven|eight|nine|\d+)\s+books?)\b/i;
 
@@ -17,6 +23,22 @@ export function normalizeIdentityTitle(title) {
 export function normalizeWorkTitle(title) {
   const withoutAnnotations = stripAudiobookAnnotations(title);
   return normalizeTitle(withoutAnnotations.split(/[-:–—]/, 1)[0]);
+}
+
+export function isCanonicalTitleReductionSafe(title) {
+  const rawTitle = String(title || '');
+  const separatorIndex = rawTitle.search(/[-:–—]/);
+  if (separatorIndex < 0) return true;
+
+  const prefix = rawTitle.slice(0, separatorIndex);
+  const suffix = rawTitle.slice(separatorIndex + 1).trim();
+  if (!suffix) return false;
+
+  return (
+    AUDIOBOOK_ANNOTATION_TEST_PATTERN.test(prefix) ||
+    SPLIT_AUDIO_PART_PATTERN.test(prefix) ||
+    SAFE_CANONICAL_SUFFIX_PATTERN.test(suffix)
+  );
 }
 
 export function isCollectionTitle(title) {

--- a/src/matching/utils/hardcover-extractor.js
+++ b/src/matching/utils/hardcover-extractor.js
@@ -267,6 +267,14 @@ export function extractActivityFromSearchResult(searchResult) {
     return Number(searchResult.rating_count) || 0;
   }
 
+  if (searchResult.users_count !== undefined) {
+    return Number(searchResult.users_count) || 0;
+  }
+
+  if (searchResult.ratings_count !== undefined) {
+    return Number(searchResult.ratings_count) || 0;
+  }
+
   // Check book-level activity
   if (searchResult.book) {
     if (searchResult.book.activity !== undefined) {
@@ -279,6 +287,14 @@ export function extractActivityFromSearchResult(searchResult) {
 
     if (searchResult.book.rating_count !== undefined) {
       return Number(searchResult.book.rating_count) || 0;
+    }
+
+    if (searchResult.book.users_count !== undefined) {
+      return Number(searchResult.book.users_count) || 0;
+    }
+
+    if (searchResult.book.ratings_count !== undefined) {
+      return Number(searchResult.book.ratings_count) || 0;
     }
   }
 

--- a/src/matching/utils/identifier-title-validator.js
+++ b/src/matching/utils/identifier-title-validator.js
@@ -1,5 +1,6 @@
 import { calculateTextSimilarity } from './text-matching.js';
 import {
+  hasConflictingExplicitWorkParts,
   isCollectionTitle,
   normalizeIdentityTitle,
   normalizeWorkTitle,
@@ -12,6 +13,9 @@ import {
  */
 export function isIdentifierTitlePlausible(sourceTitle, candidateTitle) {
   if (!sourceTitle || !candidateTitle) return true;
+  if (hasConflictingExplicitWorkParts(sourceTitle, candidateTitle)) {
+    return false;
+  }
 
   const normalizedSource = normalizeIdentityTitle(sourceTitle);
   const normalizedCandidate = normalizeIdentityTitle(candidateTitle);

--- a/src/matching/utils/identifier-title-validator.js
+++ b/src/matching/utils/identifier-title-validator.js
@@ -1,0 +1,35 @@
+import { calculateTextSimilarity, normalizeTitle } from './text-matching.js';
+
+const COLLECTION_TITLE_PATTERN =
+  /\b(?:box(?:ed)?\s+set|collection(?:\s+set)?|omnibus|bundle|(?:two|three|four|five|six|seven|eight|nine|\d+)\s+books?)\b/i;
+
+function normalizeBaseTitle(title) {
+  return normalizeTitle(String(title).split(/[-:–—]/, 1)[0]);
+}
+
+/**
+ * Check that an identifier result still resembles the source work. Identifier
+ * metadata can be attached to the wrong Hardcover record, so it should not
+ * bypass basic book-level title validation.
+ */
+export function isIdentifierTitlePlausible(sourceTitle, candidateTitle) {
+  if (!sourceTitle || !candidateTitle) return true;
+
+  const normalizedSource = normalizeTitle(sourceTitle);
+  const normalizedCandidate = normalizeTitle(candidateTitle);
+  if (!normalizedSource || !normalizedCandidate) return true;
+  if (normalizedSource === normalizedCandidate) return true;
+
+  const sourceIsCollection = COLLECTION_TITLE_PATTERN.test(sourceTitle);
+  const candidateIsCollection = COLLECTION_TITLE_PATTERN.test(candidateTitle);
+  if (candidateIsCollection && !sourceIsCollection) return false;
+
+  const sourceBase = normalizeBaseTitle(sourceTitle);
+  const candidateBase = normalizeBaseTitle(candidateTitle);
+  if (sourceBase && sourceBase === candidateBase) return true;
+
+  return (
+    calculateTextSimilarity(normalizedSource, normalizedCandidate, 'title') >=
+    0.55
+  );
+}

--- a/src/matching/utils/identifier-title-validator.js
+++ b/src/matching/utils/identifier-title-validator.js
@@ -1,11 +1,9 @@
-import { calculateTextSimilarity, normalizeTitle } from './text-matching.js';
-
-const COLLECTION_TITLE_PATTERN =
-  /\b(?:box(?:ed)?\s+set|collection(?:\s+set)?|omnibus|bundle|(?:two|three|four|five|six|seven|eight|nine|\d+)\s+books?)\b/i;
-
-function normalizeBaseTitle(title) {
-  return normalizeTitle(String(title).split(/[-:–—]/, 1)[0]);
-}
+import { calculateTextSimilarity } from './text-matching.js';
+import {
+  isCollectionTitle,
+  normalizeIdentityTitle,
+  normalizeWorkTitle,
+} from './book-title-identity.js';
 
 /**
  * Check that an identifier result still resembles the source work. Identifier
@@ -15,17 +13,17 @@ function normalizeBaseTitle(title) {
 export function isIdentifierTitlePlausible(sourceTitle, candidateTitle) {
   if (!sourceTitle || !candidateTitle) return true;
 
-  const normalizedSource = normalizeTitle(sourceTitle);
-  const normalizedCandidate = normalizeTitle(candidateTitle);
+  const normalizedSource = normalizeIdentityTitle(sourceTitle);
+  const normalizedCandidate = normalizeIdentityTitle(candidateTitle);
   if (!normalizedSource || !normalizedCandidate) return true;
   if (normalizedSource === normalizedCandidate) return true;
 
-  const sourceIsCollection = COLLECTION_TITLE_PATTERN.test(sourceTitle);
-  const candidateIsCollection = COLLECTION_TITLE_PATTERN.test(candidateTitle);
+  const sourceIsCollection = isCollectionTitle(sourceTitle);
+  const candidateIsCollection = isCollectionTitle(candidateTitle);
   if (candidateIsCollection && !sourceIsCollection) return false;
 
-  const sourceBase = normalizeBaseTitle(sourceTitle);
-  const candidateBase = normalizeBaseTitle(candidateTitle);
+  const sourceBase = normalizeWorkTitle(sourceTitle);
+  const candidateBase = normalizeWorkTitle(candidateTitle);
   if (sourceBase && sourceBase === candidateBase) return true;
 
   return (

--- a/src/matching/utils/text-matching.js
+++ b/src/matching/utils/text-matching.js
@@ -745,3 +745,10 @@ export function normalizeAsin(asin) {
   const normalized = String(asin).replace(/\s/g, '').toUpperCase();
   return /^[A-Z0-9]{10}$/.test(normalized) ? normalized : null;
 }
+
+export function getIsbn10FromNumericAsin(asin) {
+  const normalized = normalizeAsin(asin);
+  if (!normalized || !/^\d{10}$/.test(normalized)) return null;
+
+  return convertIsbn10To13(normalized) ? normalized : null;
+}

--- a/src/matching/utils/text-matching.js
+++ b/src/matching/utils/text-matching.js
@@ -301,9 +301,11 @@ function tokenSetSimilarity(str1, str2) {
 /**
  * Normalize title for matching
  * @param {string} title - Title to normalize
+ * @param {Object} options - Normalization options
+ * @param {boolean} options.normalizeNumbers - Convert written and Roman numbers to digits
  * @returns {string} - Normalized title
  */
-export function normalizeTitle(title) {
+export function normalizeTitle(title, { normalizeNumbers = true } = {}) {
   if (!title) return '';
 
   return (
@@ -337,8 +339,10 @@ export function normalizeTitle(title) {
       // Apply number normalization
       .split(' ')
       .map(word => {
-        word = normalizeRomanNumerals(word);
-        word = normalizeWrittenNumbers(word);
+        if (normalizeNumbers) {
+          word = normalizeRomanNumerals(word);
+          word = normalizeWrittenNumbers(word);
+        }
         return word;
       })
       .join(' ')
@@ -738,13 +742,6 @@ export function getIsbnVariants(isbn) {
 
 export function normalizeAsin(asin) {
   if (!asin) return null;
-  const normalized = asin.replace(/\s/g, '').toUpperCase();
-  if (
-    normalized.length === 10 &&
-    /^[A-Z]/.test(normalized) &&
-    !/^\d+$/.test(normalized)
-  ) {
-    return normalized;
-  }
-  return null;
+  const normalized = String(asin).replace(/\s/g, '').toUpperCase();
+  return /^[A-Z0-9]{10}$/.test(normalized) ? normalized : null;
 }

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2127,6 +2127,28 @@ export class SyncManager {
         return syncResult;
       }
 
+      const reservationKey = String(bookId);
+      this.autoAddReservations ||= new Map();
+      const existingReservation =
+        this.autoAddReservations.get(reservationKey);
+      if (existingReservation) {
+        logger.info(`Skipping duplicate auto-add within current sync`, {
+          title,
+          bookId,
+          editionId,
+          reservedByTitle: existingReservation.title,
+          reservedEditionId: existingReservation.editionId,
+        });
+        syncResult.actions.push(
+          `Skipped duplicate auto-add for Hardcover book ${bookId}`,
+        );
+        syncResult.status = 'skipped';
+        syncResult.reason = `Book ${bookId} already reserved for auto-add in this sync`;
+        syncResult.timing = performance.now() - startTime;
+        return syncResult;
+      }
+      this.autoAddReservations.set(reservationKey, { title, editionId });
+
       try {
         if (!this.dryRun) {
           logger.debug(`Adding title/author matched book to library`, {
@@ -2160,6 +2182,7 @@ export class SyncManager {
             }
             hardcoverMatch._isSearchResult = false; // No longer just a search result
           } else {
+            this.autoAddReservations.delete(reservationKey);
             logger.error(
               `Failed to add title/author matched book to library: API returned null`,
               {
@@ -2199,6 +2222,7 @@ export class SyncManager {
           hardcoverMatch._isSearchResult = false;
         }
       } catch (error) {
+        this.autoAddReservations.delete(reservationKey);
         logger.error(
           `Failed to add title/author matched book to library: ${error.message}`,
         );

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2371,6 +2371,7 @@ export class SyncManager {
 
     try {
       let searchResults = [];
+      let titleAuthorFailure = null;
 
       // Search for the book by ISBN or ASIN. These are read-only API calls, so
       // dry-run should still execute them to preview accurate auto-add results.
@@ -2600,6 +2601,9 @@ export class SyncManager {
                 absBook,
                 this.userId,
               );
+            titleAuthorFailure = titleAuthorMatch
+              ? null
+              : this.bookMatcher.getTitleAuthorMatchFailure?.(absBook) || null;
 
             if (titleAuthorMatch && titleAuthorMatch._isSearchResult) {
               // Final duplicate check: verify book isn't already in library
@@ -2802,19 +2806,28 @@ export class SyncManager {
             if (identifiers.asin)
               searchedIdentifiersList.push(`ASIN: ${identifiers.asin}`);
 
+            const matchWasRejected =
+              titleAuthorFailure?.outcome === 'MATCH_REJECTED';
             this._trackFailedBook(result, {
               title,
               author,
               identifiers,
-              category: 'NOT_FOUND',
-              reason:
-                'Book not found in Hardcover database after searching by identifiers and title/author',
-              suggestions: [
-                'Manually add this book to your Hardcover library first',
-                'Check if the ISBN/ASIN in Audiobookshelf metadata is correct',
-                'Try updating the book metadata in Audiobookshelf with corrected identifiers',
-                'Search for the book manually in Hardcover to see if it exists under a different title or edition',
-              ],
+              category: matchWasRejected ? 'MATCH_REJECTED' : 'NOT_FOUND',
+              reason: matchWasRejected
+                ? titleAuthorFailure.reason
+                : 'Book not found in Hardcover database after searching by identifiers and title/author',
+              suggestions: matchWasRejected
+                ? [
+                    'Review the rejected Hardcover candidate before adding it manually',
+                    'Check the title and author metadata in Audiobookshelf',
+                    'Do not lower the global confidence threshold without reviewing false-positive risk',
+                  ]
+                : [
+                    'Manually add this book to your Hardcover library first',
+                    'Check if the ISBN/ASIN in Audiobookshelf metadata is correct',
+                    'Try updating the book metadata in Audiobookshelf with corrected identifiers',
+                    'Search for the book manually in Hardcover to see if it exists under a different title or edition',
+                  ],
               details: {
                 searchedIdentifiers:
                   searchedIdentifiersList.join(', ') ||
@@ -2822,6 +2835,13 @@ export class SyncManager {
                 titleSearched: title,
                 authorSearched: author,
                 dryRun: this.dryRun,
+                rejectedCandidate: matchWasRejected
+                  ? {
+                      title: titleAuthorFailure.candidateTitle,
+                      bookId: titleAuthorFailure.candidateBookId,
+                      score: titleAuthorFailure.candidateScore,
+                    }
+                  : undefined,
               },
             });
           }

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2489,12 +2489,12 @@ export class SyncManager {
             },
             targetTitle: title,
             targetAuthor: author || 'N/A',
-            fallbackEnabled: !this.dryRun,
+            fallbackEnabled: true,
             titleAuthorId: titleAuthorId,
           },
         );
 
-        if (!this.dryRun) {
+        if (searchResults.length === 0) {
           try {
             // Use BookMatcher's title/author matching with library context
             // This enables duplicate detection and "Want to Read" update logic
@@ -2750,7 +2750,7 @@ export class SyncManager {
               `Could not find ${title} in Hardcover database after all search attempts`,
               {
                 searchedIdentifiers: identifiers,
-                titleAuthorAttempted: !this.dryRun,
+                titleAuthorAttempted: true,
                 dryRun: this.dryRun,
               },
             );

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2195,6 +2195,7 @@ export class SyncManager {
           } else {
             hardcoverMatch.userBook.id = `dry-run-${bookId}`;
           }
+          hardcoverMatch._isDryRunSimulatedAdd = true;
           hardcoverMatch._isSearchResult = false;
         }
       } catch (error) {
@@ -3258,7 +3259,16 @@ export class SyncManager {
 
       // Disable protection for force sync, or for first sync only when
       // Hardcover has no existing progress to protect.
-      if (shouldProtectAgainstRegression && isForceSync) {
+      if (
+        shouldProtectAgainstRegression &&
+        hardcoverMatch._isDryRunSimulatedAdd
+      ) {
+        shouldProtectAgainstRegression = false;
+        logger.debug(
+          `Skipping existing progress lookup for simulated addition: ${title}`,
+          { bookId: hardcoverMatch.book?.id },
+        );
+      } else if (shouldProtectAgainstRegression && isForceSync) {
         shouldProtectAgainstRegression = false;
         logger.debug(
           `Disabling progress regression protection for ${title}: force sync enabled`,

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -3995,6 +3995,15 @@ export class SyncManager {
   _updateResult(result, syncResult) {
     result.books_processed++;
 
+    const recordedAutoAdd = (syncResult.actions || []).some(
+      action =>
+        action === 'Added matched book to Hardcover library' ||
+        action === '[DRY RUN] Would add matched book to library',
+    );
+    if (recordedAutoAdd) {
+      result.books_auto_added++;
+    }
+
     // Create detailed book info for verbose output
     const bookDetail = {
       title: syncResult.title || 'Unknown Title',
@@ -4038,7 +4047,9 @@ export class SyncManager {
         result.books_completed++;
         break;
       case 'auto_added':
-        result.books_auto_added++;
+        if (!recordedAutoAdd) {
+          result.books_auto_added++;
+        }
         break;
       case 'skipped':
         result.books_skipped++;

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2432,7 +2432,7 @@ export class SyncManager {
 
         if (!hasCompatibleFormat) {
           logger.info(
-            `Format mismatch in identifier search for "${title}" - triggering title/author fallback`,
+            `Format mismatch in identifier search for "${title}" - checking other editions of the matched book`,
             {
               sourceFormat,
               identifiersSearched: {
@@ -2446,8 +2446,51 @@ export class SyncManager {
             },
           );
 
-          // Clear search results to trigger title/author fallback
-          searchResults = [];
+          const matchedBookIds = [
+            ...new Set(
+              searchResults.map(result => result.book?.id).filter(Boolean),
+            ),
+          ];
+          const compatibleEditions = [];
+
+          for (const bookId of matchedBookIds) {
+            const bookDetails =
+              await this.hardcover.getBookDetailsWithEditions(bookId);
+            if (!bookDetails?.editions) continue;
+
+            for (const edition of bookDetails.editions) {
+              const editionFormat = this._mapHardcoverFormatToInternal(edition);
+              if (this._areFormatsCompatible(sourceFormat, editionFormat)) {
+                compatibleEditions.push({
+                  ...edition,
+                  book: {
+                    id: bookDetails.id,
+                    title: bookDetails.title,
+                    contributions: bookDetails.contributions,
+                  },
+                });
+              }
+            }
+          }
+
+          if (compatibleEditions.length > 0) {
+            logger.info(
+              `Found compatible editions on identifier-matched book`,
+              {
+                title,
+                sourceFormat,
+                matchedBookIds,
+                compatibleEditionCount: compatibleEditions.length,
+              },
+            );
+            searchResults = compatibleEditions;
+          } else {
+            logger.info(
+              `No compatible edition found on identifier-matched book - triggering title/author fallback`,
+              { title, sourceFormat, matchedBookIds },
+            );
+            searchResults = [];
+          }
         }
       }
 
@@ -4193,17 +4236,15 @@ export class SyncManager {
       return true;
     }
 
-    // Audiobook and ebook are compatible (cross-digital)
-    if (
-      (sourceFormat === 'audiobook' && editionFormat === 'ebook') ||
-      (sourceFormat === 'ebook' && editionFormat === 'audiobook')
-    ) {
-      return true;
+    // An audiobook must use a listened edition so progress is recorded in
+    // seconds against the correct medium.
+    if (sourceFormat === 'audiobook') {
+      return false;
     }
 
-    // Physical edition ('book') is NOT compatible with audiobook
-    if (sourceFormat === 'audiobook' && editionFormat === 'book') {
-      return false;
+    // Ebook sources may still use an audiobook edition as a digital fallback.
+    if (sourceFormat === 'ebook' && editionFormat === 'audiobook') {
+      return true;
     }
 
     // Allow ebook → physical fallback (acceptable)

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -21,6 +21,66 @@ import { Transaction } from './utils/transaction.js';
 import SessionManager from './session-manager.js';
 import { currentVersion } from './version.js';
 
+async function acquireAutoAddReservation(manager, bookId, title, editionId) {
+  const reservationKey = String(bookId);
+  manager.autoAddReservations ||= new Map();
+
+  while (true) {
+    const existingReservation =
+      manager.autoAddReservations.get(reservationKey);
+    if (!existingReservation) {
+      let resolveCompletion;
+      const completion = new Promise(resolve => {
+        resolveCompletion = resolve;
+      });
+      const reservation = {
+        title,
+        editionId,
+        completion,
+        resolveCompletion,
+        settled: false,
+      };
+      manager.autoAddReservations.set(reservationKey, reservation);
+      return { acquired: true, reservationKey, reservation };
+    }
+
+    if (!existingReservation.completion) {
+      return {
+        acquired: false,
+        reservationKey,
+        existingReservation,
+      };
+    }
+
+    const succeeded = await existingReservation.completion;
+    if (succeeded) {
+      return {
+        acquired: false,
+        reservationKey,
+        existingReservation,
+      };
+    }
+  }
+}
+
+function settleAutoAddReservation(
+  manager,
+  reservationKey,
+  reservation,
+  succeeded,
+) {
+  if (!reservation || reservation.settled) return;
+
+  reservation.settled = true;
+  if (
+    !succeeded &&
+    manager.autoAddReservations?.get(reservationKey) === reservation
+  ) {
+    manager.autoAddReservations.delete(reservationKey);
+  }
+  reservation.resolveCompletion(succeeded);
+}
+
 export class SyncManager {
   constructor(user, globalConfig, dryRun = false, verbose = false) {
     this.user = user;
@@ -2127,11 +2187,14 @@ export class SyncManager {
         return syncResult;
       }
 
-      const reservationKey = String(bookId);
-      this.autoAddReservations ||= new Map();
-      const existingReservation =
-        this.autoAddReservations.get(reservationKey);
-      if (existingReservation) {
+      const reservationState = await acquireAutoAddReservation(
+        this,
+        bookId,
+        title,
+        editionId,
+      );
+      if (!reservationState.acquired) {
+        const { existingReservation } = reservationState;
         logger.info(`Skipping duplicate auto-add within current sync`, {
           title,
           bookId,
@@ -2147,7 +2210,6 @@ export class SyncManager {
         syncResult.timing = performance.now() - startTime;
         return syncResult;
       }
-      this.autoAddReservations.set(reservationKey, { title, editionId });
 
       try {
         if (!this.dryRun) {
@@ -2164,6 +2226,12 @@ export class SyncManager {
           );
 
           if (addResult && addResult.id) {
+            settleAutoAddReservation(
+              this,
+              reservationState.reservationKey,
+              reservationState.reservation,
+              true,
+            );
             syncResult.actions.push(`Added matched book to Hardcover library`);
 
             // Update the match object to look like a regular library match
@@ -2182,7 +2250,12 @@ export class SyncManager {
             }
             hardcoverMatch._isSearchResult = false; // No longer just a search result
           } else {
-            this.autoAddReservations.delete(reservationKey);
+            settleAutoAddReservation(
+              this,
+              reservationState.reservationKey,
+              reservationState.reservation,
+              false,
+            );
             logger.error(
               `Failed to add title/author matched book to library: API returned null`,
               {
@@ -2220,9 +2293,20 @@ export class SyncManager {
           }
           hardcoverMatch._isDryRunSimulatedAdd = true;
           hardcoverMatch._isSearchResult = false;
+          settleAutoAddReservation(
+            this,
+            reservationState.reservationKey,
+            reservationState.reservation,
+            true,
+          );
         }
       } catch (error) {
-        this.autoAddReservations.delete(reservationKey);
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          false,
+        );
         logger.error(
           `Failed to add title/author matched book to library: ${error.message}`,
         );
@@ -2409,6 +2493,8 @@ export class SyncManager {
       title: title,
       dryRun: this.dryRun,
     });
+
+    let reservationState = null;
 
     try {
       let searchResults = [];
@@ -2998,12 +3084,15 @@ export class SyncManager {
 
       const bookId = edition.book.id;
       const editionId = edition.id;
-      const reservationKey = String(bookId);
-      this.autoAddReservations ||= new Map();
-      const existingReservation =
-        this.autoAddReservations.get(reservationKey);
+      reservationState = await acquireAutoAddReservation(
+        this,
+        bookId,
+        title,
+        editionId,
+      );
 
-      if (existingReservation) {
+      if (!reservationState.acquired) {
+        const { existingReservation } = reservationState;
         logger.info(`Skipping duplicate auto-add within current sync`, {
           title,
           bookId,
@@ -3021,11 +3110,6 @@ export class SyncManager {
         };
       }
 
-      this.autoAddReservations.set(reservationKey, {
-        title,
-        editionId,
-      });
-
       logger.debug(`Found match in Hardcover`, {
         title: title,
         hardcoverTitle: edition.book.title,
@@ -3039,6 +3123,12 @@ export class SyncManager {
       if (this.dryRun) {
         logger.debug(
           `[DRY RUN] Would add ${title} to library (book_id: ${bookId}, edition_id: ${editionId})`,
+        );
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          true,
         );
         return { status: 'auto_added', title, bookId, editionId };
       }
@@ -3059,6 +3149,12 @@ export class SyncManager {
       );
 
       if (addResult) {
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          true,
+        );
         logger.info(`Successfully added ${title} to library`, {
           userBookId: addResult.id,
           hardcoverTitle: edition.book.title,
@@ -3187,6 +3283,12 @@ export class SyncManager {
           throw cacheError;
         }
       } else {
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          false,
+        );
         logger.error(`Failed to add ${title} to library`, {
           bookId: bookId,
           editionId: editionId,
@@ -3194,6 +3296,14 @@ export class SyncManager {
         return { status: 'error', reason: 'Failed to add to library', title };
       }
     } catch (error) {
+      if (reservationState?.acquired) {
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          false,
+        );
+      }
       logger.error(`Error auto-adding ${title}`, {
         error: error.message,
         stack: error.stack,

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -9,6 +9,7 @@ import {
   extractAudioDurationFromAudiobookshelf,
   extractBookIdentifiers,
   extractTitle,
+  getIsbn10FromNumericAsin,
   getIsbnVariants,
 } from './matching/index.js';
 import { isIdentifierTitlePlausible } from './matching/utils/identifier-title-validator.js';
@@ -2390,7 +2391,32 @@ export class SyncManager {
         });
       }
 
-      if (searchResults.length === 0 && identifiers.isbn) {
+      const numericAsinIsbn = getIsbn10FromNumericAsin(identifiers.asin);
+      if (searchResults.length === 0 && numericAsinIsbn) {
+        logger.info(
+          `Searching Hardcover by ISBN-10 from numeric ASIN: ${numericAsinIsbn}`,
+          { dryRun: this.dryRun },
+        );
+        searchResults =
+          await this.hardcover.searchBooksByIsbn(numericAsinIsbn);
+        logger.info(
+          `Numeric ASIN ISBN-10 search returned ${searchResults.length} results`,
+          {
+            dryRun: this.dryRun,
+            results: searchResults.map(r => ({
+              id: r.id,
+              format: r.reading_format?.format || r.physical_format,
+              title: r.book?.title,
+            })),
+          },
+        );
+      }
+
+      if (
+        searchResults.length === 0 &&
+        identifiers.isbn &&
+        identifiers.isbn !== numericAsinIsbn
+      ) {
         logger.info(`Searching Hardcover by ISBN: ${identifiers.isbn}`, {
           dryRun: this.dryRun,
         });

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2458,11 +2458,13 @@ export class SyncManager {
           sourceFormat,
         );
 
-        if (!hasCompatibleFormat) {
+        if (!hasCompatibleFormat || sourceFormat === 'audiobook') {
           logger.info(
-            `Format mismatch in identifier search for "${title}" - checking other editions of the matched book`,
+            `Checking other editions of the identifier-matched book`,
             {
+              title,
               sourceFormat,
+              identifierResultCompatible: hasCompatibleFormat,
               identifiersSearched: {
                 asin: identifiers.asin || 'N/A',
                 isbn: identifiers.isbn || 'N/A',
@@ -2481,22 +2483,25 @@ export class SyncManager {
           ];
           const compatibleEditions = [];
 
-          for (const bookId of matchedBookIds) {
-            const bookDetails =
-              await this.hardcover.getBookDetailsWithEditions(bookId);
-            if (!bookDetails?.editions) continue;
+          if (this.hardcover.getBookDetailsWithEditions) {
+            for (const bookId of matchedBookIds) {
+              const bookDetails =
+                await this.hardcover.getBookDetailsWithEditions(bookId);
+              if (!bookDetails?.editions) continue;
 
-            for (const edition of bookDetails.editions) {
-              const editionFormat = this._mapHardcoverFormatToInternal(edition);
-              if (this._areFormatsCompatible(sourceFormat, editionFormat)) {
-                compatibleEditions.push({
-                  ...edition,
-                  book: {
-                    id: bookDetails.id,
-                    title: bookDetails.title,
-                    contributions: bookDetails.contributions,
-                  },
-                });
+              for (const edition of bookDetails.editions) {
+                const editionFormat =
+                  this._mapHardcoverFormatToInternal(edition);
+                if (this._areFormatsCompatible(sourceFormat, editionFormat)) {
+                  compatibleEditions.push({
+                    ...edition,
+                    book: {
+                      id: bookDetails.id,
+                      title: bookDetails.title,
+                      contributions: bookDetails.contributions,
+                    },
+                  });
+                }
               }
             }
           }
@@ -2512,6 +2517,11 @@ export class SyncManager {
               },
             );
             searchResults = compatibleEditions;
+          } else if (hasCompatibleFormat) {
+            logger.info(
+              `Could not load other editions; keeping compatible identifier result`,
+              { title, sourceFormat, matchedBookIds },
+            );
           } else {
             logger.info(
               `No compatible edition found on identifier-matched book - triggering title/author fallback`,

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2180,6 +2180,22 @@ export class SyncManager {
           syncResult.actions.push(
             `[DRY RUN] Would add matched book to library`,
           );
+
+          // Continue through the same post-add sync path as live mode without
+          // issuing a write to Hardcover.
+          if (!hardcoverMatch.userBook) {
+            hardcoverMatch.userBook = {
+              id: `dry-run-${bookId}`,
+              book: {
+                id: bookId,
+                title: hardcoverMatch.book?.title || title,
+                contributions: [],
+              },
+            };
+          } else {
+            hardcoverMatch.userBook.id = `dry-run-${bookId}`;
+          }
+          hardcoverMatch._isSearchResult = false;
         }
       } catch (error) {
         logger.error(

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -11,6 +11,7 @@ import {
   extractTitle,
   getIsbnVariants,
 } from './matching/index.js';
+import { isIdentifierTitlePlausible } from './matching/utils/identifier-title-validator.js';
 import { formatDurationForLogging } from './utils/time.js';
 import { DateTime } from 'luxon';
 import { setMaxListeners } from 'events';
@@ -2402,6 +2403,21 @@ export class SyncManager {
             title: r.book?.title,
           })),
         });
+      }
+
+      if (searchResults.length > 0) {
+        const unvalidatedCount = searchResults.length;
+        searchResults = searchResults.filter(searchResult =>
+          isIdentifierTitlePlausible(title, searchResult.book?.title),
+        );
+
+        if (searchResults.length < unvalidatedCount) {
+          logger.warn(`Rejected identifier results with conflicting titles`, {
+            sourceTitle: title,
+            rejectedCount: unvalidatedCount - searchResults.length,
+            remainingCount: searchResults.length,
+          });
+        }
       }
 
       // Check format compatibility after identifier search

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -31,6 +31,7 @@ export class SyncManager {
     const workers = this.globalConfig.workers || 3;
     this.taskQueue = new TaskQueue({ concurrency: workers });
     this.abortController = new AbortController();
+    this.autoAddReservations = new Map();
 
     this.timezone = globalConfig.timezone || 'UTC';
 
@@ -98,6 +99,7 @@ export class SyncManager {
 
   async syncProgress() {
     const startTime = Date.now();
+    this.autoAddReservations.clear();
     logger.info('Starting sync for user', {
       service: 'shelfbridge',
       version: currentVersion,
@@ -2899,6 +2901,33 @@ export class SyncManager {
 
       const bookId = edition.book.id;
       const editionId = edition.id;
+      const reservationKey = String(bookId);
+      this.autoAddReservations ||= new Map();
+      const existingReservation =
+        this.autoAddReservations.get(reservationKey);
+
+      if (existingReservation) {
+        logger.info(`Skipping duplicate auto-add within current sync`, {
+          title,
+          bookId,
+          editionId,
+          reservedByTitle: existingReservation.title,
+          reservedEditionId: existingReservation.editionId,
+        });
+        return {
+          status: 'skipped',
+          reason: `Book ${bookId} already reserved for auto-add in this sync`,
+          title,
+          bookId,
+          editionId,
+          duplicate: true,
+        };
+      }
+
+      this.autoAddReservations.set(reservationKey, {
+        title,
+        editionId,
+      });
 
       logger.debug(`Found match in Hardcover`, {
         title: title,

--- a/tests/audiobookshelf-duration-extraction.test.js
+++ b/tests/audiobookshelf-duration-extraction.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { extractAudioDurationFromAudiobookshelf } from '../src/matching/utils/audiobookshelf-extractor.js';
+
+describe('Audiobookshelf duration extraction', () => {
+  it('sums audio-file durations from a standard item response', () => {
+    const duration = extractAudioDurationFromAudiobookshelf({
+      media: {
+        audioFiles: [
+          { duration: 1200.5 },
+          { duration: 1800.25 },
+          { duration: null },
+        ],
+      },
+    });
+
+    assert.equal(duration, 3000.75);
+  });
+
+  it('prefers the aggregate media duration when ABS supplies it', () => {
+    const duration = extractAudioDurationFromAudiobookshelf({
+      media: {
+        duration: 3000,
+        audioFiles: [{ duration: 2999.5 }],
+      },
+    });
+
+    assert.equal(duration, 3000);
+  });
+
+  it('returns null when no positive duration is available', () => {
+    const duration = extractAudioDurationFromAudiobookshelf({
+      media: {
+        audioFiles: [{ duration: 0 }, { duration: 'unknown' }],
+      },
+    });
+
+    assert.equal(duration, null);
+  });
+});

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -120,4 +120,45 @@ describe('Audiobook auto-add edition selection', () => {
     assert.equal(result.bookId, 'rhythm-book');
     assert.equal(result.editionId, 'different-duration-audiobook');
   });
+
+  it('uses summed ABS file duration to choose the closest audiobook edition', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'far-duration-audiobook',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 40000,
+          users_count: 10,
+        },
+        {
+          id: 'close-duration-audiobook',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 20500,
+          users_count: 10,
+        },
+      ],
+    });
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          audioFiles: [{ duration: 10000 }, { duration: 10000 }],
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(result.editionId, 'close-duration-audiobook');
+  });
 });

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -161,4 +161,58 @@ describe('Audiobook auto-add edition selection', () => {
     assert.equal(result.bookId, 'rhythm-book');
     assert.equal(result.editionId, 'close-duration-audiobook');
   });
+
+  it('checks same-book editions when the identifier audiobook has the wrong duration', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'identifier-audiobook',
+          asin: 'B082FARAWAY',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 40000,
+          users_count: 10,
+        },
+        {
+          id: 'different-identifier-close-audiobook',
+          asin: 'B082CLOSER1',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 20500,
+          users_count: 10,
+        },
+      ],
+    });
+    manager.hardcover.searchBooksByIsbn = mock.fn(async () => [
+      {
+        id: 'identifier-audiobook',
+        reading_format: { format: 'Listened' },
+        audio_seconds: 40000,
+        book: { id: 'rhythm-book', title: 'Rhythm of War' },
+      },
+    ]);
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          audioFiles: [{ duration: 10000 }, { duration: 10000 }],
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(
+      result.editionId,
+      'different-identifier-close-audiobook',
+    );
+  });
 });

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { SyncManager } from '../src/sync-manager.js';
+
+function createManager(bookDetails) {
+  return {
+    userId: 'test-user',
+    dryRun: true,
+    globalConfig: { force_sync: false },
+    hardcover: {
+      searchBooksByAsin: mock.fn(async () => []),
+      searchBooksByIsbn: mock.fn(async () => [
+        {
+          id: 'ebook-edition',
+          isbn_13: '9781429952040',
+          reading_format: { format: 'Ebook' },
+          book: { id: 'rhythm-book', title: 'Rhythm of War' },
+        },
+      ]),
+      getBookDetailsWithEditions: mock.fn(async () => bookDetails),
+      addBookToLibrary: mock.fn(),
+    },
+    cache: {
+      generateTitleAuthorIdentifier: () =>
+        'title_author:rhythm_of_war|brandon_sanderson',
+      getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+    },
+    _checkFormatCompatibility:
+      SyncManager.prototype._checkFormatCompatibility,
+    _mapHardcoverFormatToInternal:
+      SyncManager.prototype._mapHardcoverFormatToInternal,
+    _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+  };
+}
+
+describe('Audiobook auto-add edition selection', () => {
+  it('does not treat an ebook edition as audiobook-compatible', () => {
+    assert.equal(
+      SyncManager.prototype._areFormatsCompatible('audiobook', 'ebook'),
+      false,
+    );
+  });
+
+  it('keeps the identifier-matched book and selects its audiobook edition', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'ebook-edition',
+          reading_format: { format: 'Ebook' },
+          pages: 1213,
+        },
+        {
+          id: 'audiobook-edition',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 206760,
+          users_count: 50,
+        },
+      ],
+    });
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        duration: 190000,
+        media: {
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(result.editionId, 'audiobook-edition');
+    assert.equal(
+      manager.hardcover.getBookDetailsWithEditions.mock.callCount(),
+      1,
+    );
+    assert.equal(manager.hardcover.addBookToLibrary.mock.callCount(), 0);
+  });
+
+  it('keeps the correct book when its audiobook duration differs', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'different-duration-audiobook',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 250000,
+        },
+      ],
+    });
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        duration: 190000,
+        media: {
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(result.editionId, 'different-duration-audiobook');
+  });
+});

--- a/tests/auto-add-run-deduplication.test.js
+++ b/tests/auto-add-run-deduplication.test.js
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Within-run auto-add deduplication', () => {
+  it('reserves a Hardcover book before concurrent dry-run additions', async () => {
+    const hardcoverBook = { id: 'lost-metal-book', title: 'The Lost Metal' };
+    const searchBooksByAsin = mock.fn(async () => [
+      {
+        id: 'lost-metal-audio',
+        asin: 'B09N7MXRNZ',
+        audio_seconds: 67620,
+        reading_format: { format: 'Listened' },
+        book: hardcoverBook,
+      },
+    ]);
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      globalConfig: { force_sync: false },
+      autoAddReservations: new Map(),
+      hardcover: {
+        searchBooksByAsin,
+        searchBooksByIsbn: mock.fn(async () => []),
+        addBookToLibrary: mock.fn(),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_lost_metal|brandon_sanderson',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+    const createAbsBook = (id, duration) => ({
+      id,
+      media: {
+        audioFiles: [{ duration }],
+        metadata: {
+          title: 'The Lost Metal: A Mistborn Novel',
+          author: 'Brandon Sanderson',
+        },
+      },
+    });
+    const identifiers = { asin: 'B09N7MXRNZ', isbn: null };
+
+    const results = await Promise.all([
+      SyncManager.prototype._tryAutoAddBook.call(
+        manager,
+        createAbsBook('abs-lost-metal-standard', 67620),
+        identifiers,
+        'The Lost Metal: A Mistborn Novel',
+        'Brandon Sanderson',
+      ),
+      SyncManager.prototype._tryAutoAddBook.call(
+        manager,
+        createAbsBook('abs-lost-metal-full-cast', 56822),
+        identifiers,
+        'The Lost Metal: A Mistborn Novel',
+        'Brandon Sanderson',
+      ),
+    ]);
+
+    assert.deepEqual(
+      results.map(result => result.status).sort(),
+      ['auto_added', 'skipped'],
+    );
+    assert.equal(results.filter(result => result.duplicate).length, 1);
+    assert.equal(manager.autoAddReservations.size, 1);
+    assert.equal(manager.hardcover.addBookToLibrary.mock.callCount(), 0);
+  });
+});

--- a/tests/auto-add-run-deduplication.test.js
+++ b/tests/auto-add-run-deduplication.test.js
@@ -3,66 +3,75 @@ import { describe, it, mock } from 'node:test';
 
 import { SyncManager } from '../src/sync-manager.js';
 
+const hardcoverBook = { id: 'lost-metal-book', title: 'The Lost Metal' };
+const identifiers = { asin: 'B09N7MXRNZ', isbn: null };
+
+function createAbsBook(id, duration = 67620) {
+  return {
+    id,
+    media: {
+      audioFiles: [{ duration }],
+      metadata: {
+        title: 'The Lost Metal: A Mistborn Novel',
+        author: 'Brandon Sanderson',
+      },
+    },
+  };
+}
+
+function createManager({
+  dryRun = false,
+  addBookToLibrary = mock.fn(),
+  storeBookSyncData = mock.fn(async () => {}),
+} = {}) {
+  return {
+    userId: 'test-user',
+    dryRun,
+    globalConfig: { force_sync: false },
+    autoAddReservations: new Map(),
+    hardcover: {
+      searchBooksByAsin: mock.fn(async () => [
+        {
+          id: 'lost-metal-audio',
+          asin: 'B09N7MXRNZ',
+          audio_seconds: 67620,
+          reading_format: { format: 'Listened' },
+          book: hardcoverBook,
+        },
+      ]),
+      searchBooksByIsbn: mock.fn(async () => []),
+      addBookToLibrary,
+    },
+    cache: {
+      generateTitleAuthorIdentifier: () =>
+        'title_author:the_lost_metal|brandon_sanderson',
+      getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      storeBookSyncData,
+    },
+    _checkFormatCompatibility: SyncManager.prototype._checkFormatCompatibility,
+    _mapHardcoverFormatToInternal:
+      SyncManager.prototype._mapHardcoverFormatToInternal,
+    _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+  };
+}
+
+function tryAutoAdd(manager, id) {
+  return SyncManager.prototype._tryAutoAddBook.call(
+    manager,
+    createAbsBook(id),
+    identifiers,
+    'The Lost Metal: A Mistborn Novel',
+    'Brandon Sanderson',
+  );
+}
+
 describe('Within-run auto-add deduplication', () => {
   it('reserves a Hardcover book before concurrent dry-run additions', async () => {
-    const hardcoverBook = { id: 'lost-metal-book', title: 'The Lost Metal' };
-    const searchBooksByAsin = mock.fn(async () => [
-      {
-        id: 'lost-metal-audio',
-        asin: 'B09N7MXRNZ',
-        audio_seconds: 67620,
-        reading_format: { format: 'Listened' },
-        book: hardcoverBook,
-      },
-    ]);
-    const manager = {
-      userId: 'test-user',
-      dryRun: true,
-      globalConfig: { force_sync: false },
-      autoAddReservations: new Map(),
-      hardcover: {
-        searchBooksByAsin,
-        searchBooksByIsbn: mock.fn(async () => []),
-        addBookToLibrary: mock.fn(),
-      },
-      cache: {
-        generateTitleAuthorIdentifier: () =>
-          'title_author:the_lost_metal|brandon_sanderson',
-        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
-      },
-      _checkFormatCompatibility:
-        SyncManager.prototype._checkFormatCompatibility,
-      _mapHardcoverFormatToInternal:
-        SyncManager.prototype._mapHardcoverFormatToInternal,
-      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
-    };
-    const createAbsBook = (id, duration) => ({
-      id,
-      media: {
-        audioFiles: [{ duration }],
-        metadata: {
-          title: 'The Lost Metal: A Mistborn Novel',
-          author: 'Brandon Sanderson',
-        },
-      },
-    });
-    const identifiers = { asin: 'B09N7MXRNZ', isbn: null };
+    const manager = createManager({ dryRun: true });
 
     const results = await Promise.all([
-      SyncManager.prototype._tryAutoAddBook.call(
-        manager,
-        createAbsBook('abs-lost-metal-standard', 67620),
-        identifiers,
-        'The Lost Metal: A Mistborn Novel',
-        'Brandon Sanderson',
-      ),
-      SyncManager.prototype._tryAutoAddBook.call(
-        manager,
-        createAbsBook('abs-lost-metal-full-cast', 56822),
-        identifiers,
-        'The Lost Metal: A Mistborn Novel',
-        'Brandon Sanderson',
-      ),
+      tryAutoAdd(manager, 'abs-lost-metal-standard'),
+      tryAutoAdd(manager, 'abs-lost-metal-full-cast'),
     ]);
 
     assert.deepEqual(
@@ -72,5 +81,77 @@ describe('Within-run auto-add deduplication', () => {
     assert.equal(results.filter(result => result.duplicate).length, 1);
     assert.equal(manager.autoAddReservations.size, 1);
     assert.equal(manager.hardcover.addBookToLibrary.mock.callCount(), 0);
+  });
+
+  it('releases a reservation when the add returns null', async () => {
+    const addBookToLibrary = mock.fn(async () => null);
+    const manager = createManager({ addBookToLibrary });
+
+    const first = await tryAutoAdd(manager, 'abs-first');
+    const second = await tryAutoAdd(manager, 'abs-second');
+
+    assert.equal(first.status, 'error');
+    assert.equal(second.status, 'error');
+    assert.equal(addBookToLibrary.mock.callCount(), 2);
+    assert.equal(manager.autoAddReservations.size, 0);
+  });
+
+  it('releases a reservation when the add throws', async () => {
+    const addBookToLibrary = mock.fn(async () => {
+      throw new Error('temporary add failure');
+    });
+    const manager = createManager({ addBookToLibrary });
+
+    const first = await tryAutoAdd(manager, 'abs-first');
+    const second = await tryAutoAdd(manager, 'abs-second');
+
+    assert.equal(first.status, 'error');
+    assert.equal(second.status, 'error');
+    assert.equal(addBookToLibrary.mock.callCount(), 2);
+    assert.equal(manager.autoAddReservations.size, 0);
+  });
+
+  it('lets a concurrent duplicate retry after the owner add fails', async () => {
+    let resolveFirstAdd;
+    const firstAdd = new Promise(resolve => {
+      resolveFirstAdd = resolve;
+    });
+    const addBookToLibrary = mock.fn(async () => {
+      if (addBookToLibrary.mock.callCount() === 1) return firstAdd;
+      return null;
+    });
+    const manager = createManager({ addBookToLibrary });
+
+    const firstPromise = tryAutoAdd(manager, 'abs-first');
+    await new Promise(resolve => setImmediate(resolve));
+    const secondPromise = tryAutoAdd(manager, 'abs-second');
+    resolveFirstAdd(null);
+    const results = await Promise.all([firstPromise, secondPromise]);
+
+    assert.deepEqual(
+      results.map(result => result.status),
+      ['error', 'error'],
+    );
+    assert.equal(addBookToLibrary.mock.callCount(), 2);
+    assert.equal(manager.autoAddReservations.size, 0);
+  });
+
+  it('retains the reservation after a successful add if caching fails', async () => {
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+    const manager = createManager({
+      addBookToLibrary,
+      storeBookSyncData: mock.fn(async () => {
+        throw new Error('cache unavailable');
+      }),
+    });
+
+    const first = await tryAutoAdd(manager, 'abs-first');
+    const second = await tryAutoAdd(manager, 'abs-second');
+
+    assert.equal(first.status, 'error');
+    assert.equal(second.status, 'skipped');
+    assert.equal(second.duplicate, true);
+    assert.equal(addBookToLibrary.mock.callCount(), 1);
+    assert.equal(manager.autoAddReservations.size, 1);
   });
 });

--- a/tests/book-cache-transaction-timeout.test.js
+++ b/tests/book-cache-transaction-timeout.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { BookCache } from '../src/book-cache.js';
+
+describe('BookCache transaction timeout', () => {
+  it('applies and restores the configured SQLite busy timeout', async () => {
+    const cache = new BookCache(':memory:');
+    await cache.init();
+
+    try {
+      cache.db.pragma('busy_timeout = 1234');
+      const results = await cache.executeTransaction(
+        [() => cache.db.pragma('busy_timeout', { simple: true })],
+        { timeout: 4321, description: 'timeout regression test' },
+      );
+
+      assert.deepEqual(results, [4321]);
+      assert.equal(
+        cache.db.pragma('busy_timeout', { simple: true }),
+        1234,
+      );
+    } finally {
+      cache.close();
+    }
+  });
+});

--- a/tests/book-identification-scorer.test.js
+++ b/tests/book-identification-scorer.test.js
@@ -118,6 +118,34 @@ describe('BookIdentificationScorer', () => {
       );
     });
 
+    it('should prefer a canonical search result using users_count activity', () => {
+      const canonical = calculateBookIdentificationScore(
+        {
+          title: 'A Crown of Swords',
+          author_names: ['Robert Jordan'],
+          publication_year: 1996,
+          users_count: 2039,
+        },
+        'A Crown of Swords: Book Seven of The Wheel of Time',
+        'Robert Jordan',
+        { publicationYear: 2006 },
+      );
+      const duplicate = calculateBookIdentificationScore(
+        {
+          title: 'A Crown of Swords',
+          author_names: ['Jordan, Robert'],
+          users_count: 1,
+        },
+        'A Crown of Swords: Book Seven of The Wheel of Time',
+        'Robert Jordan',
+        { publicationYear: 2006 },
+      );
+
+      assert.ok(canonical.totalScore > duplicate.totalScore);
+      assert.equal(canonical.breakdown.activity.value, 2039);
+      assert.equal(duplicate.breakdown.activity.value, 1);
+    });
+
     it('should apply publication year scoring correctly', () => {
       const searchResult = {
         title: 'Recent Book',

--- a/tests/failed-match-classification.test.js
+++ b/tests/failed-match-classification.test.js
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matcher.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+function createResult() {
+  return {
+    failed_books: [],
+    books_not_found: 0,
+    books_match_rejected: 0,
+    books_already_in_library: 0,
+  };
+}
+
+describe('Failed match classification', () => {
+  it('retains rejection details for an unsafe title/author candidate', async () => {
+    const absBook = {
+      title: 'Defiance of the Fall: A LitRPG Adventure',
+      author: 'TheFirstDefier, JF Brink',
+    };
+    const matcher = new TitleAuthorMatcher(
+      {
+        searchBooksForMatching: mock.fn(async () => [
+          {
+            id: 'defiance-15',
+            title: 'Defiance of the Fall 15',
+            contributions: [
+              { author: { name: 'TheFirstDefier' } },
+              { author: { name: 'JF Brink' } },
+            ],
+          },
+        ]),
+      },
+      {
+        generateTitleAuthorIdentifier: () => 'title-author-key',
+        getCachedBookInfo: mock.fn(async () => null),
+      },
+      { title_author_matching: { confidence_threshold: 0.7 } },
+    );
+
+    assert.equal(await matcher.findMatch(absBook, 'test-user'), null);
+    const failure = matcher.getMatchFailure(absBook);
+    assert.equal(failure.outcome, 'MATCH_REJECTED');
+    assert.match(failure.reason, /^Best candidate scored \d+\.\d%/);
+    assert.equal(failure.candidateTitle, 'Defiance of the Fall 15');
+    assert.equal(failure.candidateBookId, 'defiance-15');
+    assert.ok(failure.candidateScore >= 60 && failure.candidateScore < 70);
+  });
+
+  it('reports rejected candidates separately from books that were not found', async () => {
+    const absBook = {
+      media: {
+        metadata: {
+          title: 'Defiance of the Fall: A LitRPG Adventure',
+          author: 'TheFirstDefier, JF Brink',
+        },
+      },
+    };
+    const failure = {
+      outcome: 'MATCH_REJECTED',
+      reason: 'Best candidate scored 63.3% below the configured threshold',
+      candidateTitle: 'Defiance of the Fall 15',
+      candidateBookId: 'defiance-15',
+      candidateScore: 63.3,
+    };
+    const result = createResult();
+    const manager = {
+      dryRun: true,
+      userId: 'test-user',
+      globalConfig: { force_sync: false },
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => []),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () => 'title-author-key',
+        getCachedBookInfo: mock.fn(async () => null),
+      },
+      bookMatcher: {
+        findMatchByTitleAuthor: mock.fn(async () => null),
+        getTitleAuthorMatchFailure: mock.fn(() => failure),
+      },
+      _trackFailedBook: SyncManager.prototype._trackFailedBook,
+    };
+
+    await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      absBook,
+      { asin: 'B094JZMCJX' },
+      'Defiance of the Fall: A LitRPG Adventure',
+      'TheFirstDefier, JF Brink',
+      result,
+    );
+
+    assert.equal(result.books_match_rejected, 1);
+    assert.equal(result.books_not_found, 0);
+    assert.equal(result.failed_books[0].category, 'MATCH_REJECTED');
+    assert.deepEqual(result.failed_books[0].details.rejectedCandidate, {
+      title: 'Defiance of the Fall 15',
+      bookId: 'defiance-15',
+      score: 63.3,
+    });
+  });
+});

--- a/tests/identifier-search-result-edition.test.js
+++ b/tests/identifier-search-result-edition.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { BookMatcher } from '../src/matching/book-matcher.js';
+
+function createMatcher(hardcoverClient) {
+  const matcher = new BookMatcher(hardcoverClient, null, {});
+  matcher.formatMapper = edition => {
+    const format = edition.reading_format?.format;
+    return format === 'Listened' ? 'audiobook' : 'ebook';
+  };
+  return matcher;
+}
+
+describe('Identifier search-result edition selection', () => {
+  it('uses an ISBN to identify the work and selects the duration-matched audiobook edition', async () => {
+    const exactIsbnEdition = {
+      id: 30432880,
+      pages: 624,
+      reading_format: { format: 'Ebook' },
+      book: { id: 427383, title: 'The Well of Ascension' },
+    };
+    const audiobookEdition = {
+      id: 30616150,
+      audio_seconds: 80084,
+      reading_format: { format: 'Listened' },
+      users_count: 3,
+    };
+    const matcher = createMatcher({
+      getBookDetailsWithEditions: async () => ({
+        id: 427383,
+        title: 'The Well of Ascension',
+        editions: [exactIsbnEdition, audiobookEdition],
+      }),
+    });
+
+    const result = await matcher._enhanceIdentifierSearchResultEdition(
+      {
+        userBook: null,
+        edition: exactIsbnEdition,
+        _matchType: 'isbn_search_result',
+        _isSearchResult: true,
+      },
+      {
+        media: {
+          duration: 80088.55,
+          metadata: { narrator: 'Michael Kramer' },
+        },
+      },
+      'audiobook',
+      'isbn_search_result',
+    );
+
+    assert.equal(result.edition.id, 30616150);
+    assert.equal(result.edition.book.id, 427383);
+    assert.equal(result.edition.format, 'audiobook');
+    assert.equal(result._editionUpgraded, true);
+    assert.equal(result._originalEditionId, 30432880);
+  });
+
+  it('does not fetch alternatives for a usable exact audiobook result', async () => {
+    let fetchCount = 0;
+    const matcher = createMatcher({
+      getBookDetailsWithEditions: async () => {
+        fetchCount++;
+        return null;
+      },
+    });
+    const match = {
+      edition: {
+        id: 30404159,
+        audio_seconds: 49560,
+        reading_format: { format: 'Listened' },
+        book: { id: 427565, title: 'Ready Player Two' },
+      },
+      _isSearchResult: true,
+    };
+
+    const result = await matcher._enhanceIdentifierSearchResultEdition(
+      match,
+      { media: { duration: 49560 } },
+      'audiobook',
+      'asin_search_result',
+    );
+
+    assert.strictEqual(result, match);
+    assert.equal(fetchCount, 0);
+  });
+});

--- a/tests/identifier-title-validation.test.js
+++ b/tests/identifier-title-validation.test.js
@@ -31,6 +31,13 @@ describe('Identifier title validation', () => {
       ),
       true,
     );
+    assert.equal(
+      isIdentifierTitlePlausible(
+        "The Emperor's Soul [Dramatized Adaptation]: Elantris",
+        "The Emperor's Soul",
+      ),
+      true,
+    );
   });
 
   it('does not return a conflicting global ASIN result', async () => {

--- a/tests/identifier-title-validation.test.js
+++ b/tests/identifier-title-validation.test.js
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { AsinMatcher } from '../src/matching/strategies/asin-matcher.js';
+import { isIdentifierTitlePlausible } from '../src/matching/utils/identifier-title-validator.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Identifier title validation', () => {
+  it('rejects a single book mapped to a multi-book collection', () => {
+    assert.equal(
+      isIdentifierTitlePlausible(
+        'Fourth Wing: Empyrean, Book 1',
+        'The Empyrean Series, 3 Books Collection Set, Fourth Wing, Iron Flame, Onyx Storm, by Rebecca Yarros',
+      ),
+      false,
+    );
+  });
+
+  it('accepts common subtitle differences for the same book', () => {
+    assert.equal(
+      isIdentifierTitlePlausible(
+        'Ready Player Two: A Novel',
+        'Ready Player Two',
+      ),
+      true,
+    );
+    assert.equal(
+      isIdentifierTitlePlausible(
+        'The Way of Kings: The Stormlight Archive, Book 1',
+        'The Way of Kings',
+      ),
+      true,
+    );
+  });
+
+  it('does not return a conflicting global ASIN result', async () => {
+    const matcher = new AsinMatcher({
+      searchBooksByAsin: mock.fn(async () => [
+        {
+          id: 'collection-edition',
+          book: {
+            id: 'collection-book',
+            title:
+              'The Empyrean Series, 3 Books Collection Set, Fourth Wing, Iron Flame, Onyx Storm, by Rebecca Yarros',
+          },
+        },
+      ]),
+    });
+
+    const result = await matcher.findMatch(
+      { media: { metadata: { title: 'Fourth Wing: Empyrean, Book 1' } } },
+      { asin: 'B0BVD25SYT' },
+      {},
+      () => null,
+    );
+
+    assert.equal(result, null);
+  });
+
+  it('falls back to title matching after rejecting an identifier title', async () => {
+    const correctBook = { id: 'fourth-wing-book', title: 'Fourth Wing' };
+    const correctEdition = {
+      id: 'fourth-wing-audio',
+      book: correctBook,
+      audio_seconds: 76920,
+      reading_format: { format: 'Listened' },
+    };
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      hardcoverBooks: [],
+      globalConfig: { force_sync: false },
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => [
+          {
+            id: 'collection-edition',
+            book: {
+              id: 'collection-book',
+              title:
+                'The Empyrean Series, 3 Books Collection Set, Fourth Wing, Iron Flame, Onyx Storm, by Rebecca Yarros',
+            },
+            reading_format: { format: 'Listened' },
+          },
+        ]),
+        addBookToLibrary: mock.fn(),
+      },
+      bookMatcher: {
+        findMatchByTitleAuthor: mock.fn(async () => ({
+          userBook: null,
+          book: correctBook,
+          edition: correctEdition,
+          _matchType: 'title_author_two_stage',
+          _isSearchResult: true,
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:fourth_wing|rebecca_yarros',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          metadata: {
+            title: 'Fourth Wing: Empyrean, Book 1',
+            author: 'Rebecca Yarros',
+          },
+        },
+      },
+      { asin: 'B0BVD25SYT', isbn: null },
+      'Fourth Wing: Empyrean, Book 1',
+      'Rebecca Yarros',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'fourth-wing-book');
+    assert.equal(result.editionId, 'fourth-wing-audio');
+  });
+});

--- a/tests/numbered-title-matching.test.js
+++ b/tests/numbered-title-matching.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { calculateBookIdentificationScore } from '../src/matching/scoring/book-identification-scorer.js';
+import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matcher.js';
+import { normalizeAsin } from '../src/matching/utils/text-matching.js';
+
+describe('Numbered title matching', () => {
+  it('accepts numeric ISBN-10-style ASINs', () => {
+    assert.equal(normalizeAsin('0593396960'), '0593396960');
+  });
+
+  it('preserves written numbers in Hardcover search queries', async () => {
+    const searches = [];
+    const hardcoverClient = {
+      async searchBooksForMatching(...args) {
+        searches.push(args);
+        return [];
+      },
+    };
+    const cache = {
+      generateTitleAuthorIdentifier(title, author) {
+        return `title_author:${title}|${author}`;
+      },
+      async getCachedBookInfo() {
+        return null;
+      },
+    };
+    const matcher = new TitleAuthorMatcher(hardcoverClient, cache, {});
+
+    await matcher.findMatch(
+      {
+        title: 'Ready Player Two',
+        subtitle: 'A Novel',
+        author: 'Ernest Cline',
+      },
+      'test-user',
+    );
+
+    assert.equal(searches.length, 1);
+    assert.equal(searches[0][0], 'ready player two');
+  });
+
+  it('rejects otherwise-similar titles with conflicting numbers', () => {
+    const score = calculateBookIdentificationScore(
+      {
+        title: 'Ready Player One',
+        author_names: ['Ernest Cline'],
+        publication_year: 2008,
+      },
+      'Ready Player Two: A Novel',
+      'Ernest Cline',
+      { publicationYear: 2020 },
+    );
+
+    assert.equal(score.totalScore, 0);
+    assert.equal(score.isBookMatch, false);
+    assert.ok(score.breakdown.titleNumberMismatchPenalty);
+  });
+
+  it('allows equivalent written and numeric title numbers', () => {
+    const score = calculateBookIdentificationScore(
+      {
+        title: 'Ready Player 2',
+        author_names: ['Ernest Cline'],
+        publication_year: 2020,
+      },
+      'Ready Player Two: A Novel',
+      'Ernest Cline',
+      { publicationYear: 2020 },
+    );
+
+    assert.equal(score.isBookMatch, true);
+    assert.equal(score.breakdown.titleNumberMismatchPenalty, undefined);
+  });
+});

--- a/tests/numbered-title-matching.test.js
+++ b/tests/numbered-title-matching.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { calculateBookIdentificationScore } from '../src/matching/scoring/book-identification-scorer.js';
 import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matcher.js';
+import { isIdentifierTitlePlausible } from '../src/matching/utils/identifier-title-validator.js';
 import { normalizeAsin } from '../src/matching/utils/text-matching.js';
 
 describe('Numbered title matching', () => {
@@ -71,5 +72,45 @@ describe('Numbered title matching', () => {
 
     assert.equal(score.isBookMatch, true);
     assert.equal(score.breakdown.titleNumberMismatchPenalty, undefined);
+  });
+
+  it('rejects conflicting explicit volume numbers before normalization', () => {
+    const score = calculateBookIdentificationScore(
+      {
+        title: 'Overlord Vol. 9',
+        author_names: ['Kugane Maruyama'],
+      },
+      'Overlord Vol. 1',
+      'Kugane Maruyama',
+    );
+
+    assert.equal(score.totalScore, 0);
+    assert.equal(score.isBookMatch, false);
+    assert.equal(score.strongIdentityEvidence.matches, false);
+    assert.equal(score.strongIdentityEvidence.explicitWorkPartConflict, true);
+    assert.ok(score.breakdown.titleNumberMismatchPenalty);
+    assert.equal(
+      isIdentifierTitlePlausible('Overlord Vol. 1', 'Overlord Vol. 9'),
+      false,
+    );
+  });
+
+  it('allows equivalent Roman and numeric volume numbers', () => {
+    const score = calculateBookIdentificationScore(
+      {
+        title: 'Overlord Vol. 2',
+        author_names: ['Kugane Maruyama'],
+      },
+      'Overlord Volume II',
+      'Kugane Maruyama',
+    );
+
+    assert.equal(score.isBookMatch, true);
+    assert.equal(score.strongIdentityEvidence.explicitWorkPartConflict, false);
+    assert.equal(score.breakdown.titleNumberMismatchPenalty, undefined);
+    assert.equal(
+      isIdentifierTitlePlausible('Overlord Volume II', 'Overlord Vol. 2'),
+      true,
+    );
   });
 });

--- a/tests/numeric-asin-isbn-fallback.test.js
+++ b/tests/numeric-asin-isbn-fallback.test.js
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { AsinMatcher } from '../src/matching/strategies/asin-matcher.js';
+import { getIsbn10FromNumericAsin } from '../src/matching/utils/text-matching.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Numeric ASIN ISBN-10 fallback', () => {
+  it('only treats valid numeric ISBN-10 values as fallback candidates', () => {
+    assert.equal(getIsbn10FromNumericAsin('1250759781'), '1250759781');
+    assert.equal(getIsbn10FromNumericAsin('B082FQRWWR'), null);
+    assert.equal(getIsbn10FromNumericAsin('1250759782'), null);
+  });
+
+  it('retries a failed numeric ASIN lookup as ISBN-10 in AsinMatcher', async () => {
+    const searchBooksByAsin = mock.fn(async () => []);
+    const searchBooksByIsbn = mock.fn(async () => [
+      {
+        id: 'rhythm-audio',
+        isbn_10: '1250759781',
+        reading_format: { format: 'Listened' },
+        book: { id: 'rhythm-book', title: 'Rhythm of War' },
+      },
+    ]);
+    const matcher = new AsinMatcher({
+      searchBooksByAsin,
+      searchBooksByIsbn,
+    });
+
+    const result = await matcher.findMatch(
+      {
+        media: {
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+          },
+        },
+      },
+      { asin: '1250759781' },
+      {},
+      () => null,
+    );
+
+    assert.equal(result.edition.id, 'rhythm-audio');
+    assert.equal(result._matchType, 'isbn_search_result');
+    assert.equal(searchBooksByAsin.mock.callCount(), 1);
+    assert.equal(searchBooksByIsbn.mock.callCount(), 1);
+    assert.equal(searchBooksByIsbn.mock.calls[0].arguments[0], '1250759781');
+  });
+
+  it('prefers numeric-ASIN ISBN results over a separate ebook ISBN', async () => {
+    const searchBooksByIsbn = mock.fn(async isbn =>
+      isbn === '1250759781'
+        ? [
+            {
+              id: 'rhythm-audio',
+              isbn_10: isbn,
+              audio_seconds: 206760,
+              reading_format: { format: 'Listened' },
+              book: { id: 'rhythm-book', title: 'Rhythm of War' },
+            },
+          ]
+        : [
+            {
+              id: 'rhythm-ebook',
+              isbn_13: isbn,
+              reading_format: { format: 'Ebook' },
+              book: { id: 'rhythm-book', title: 'Rhythm of War' },
+            },
+          ],
+    );
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      globalConfig: { force_sync: false },
+      autoAddReservations: new Map(),
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => []),
+        searchBooksByIsbn,
+        addBookToLibrary: mock.fn(),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:rhythm_of_war|brandon_sanderson',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          audioFiles: [{ duration: 206700 }],
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: '1250759781', isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.editionId, 'rhythm-audio');
+    assert.equal(searchBooksByIsbn.mock.callCount(), 1);
+    assert.equal(searchBooksByIsbn.mock.calls[0].arguments[0], '1250759781');
+  });
+
+  it('does not run ISBN fallback when a numeric ASIN already matches', async () => {
+    const searchBooksByIsbn = mock.fn(async () => []);
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      globalConfig: { force_sync: false },
+      autoAddReservations: new Map(),
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => [
+          {
+            id: 'ready-player-two-audio',
+            asin: '0593396960',
+            reading_format: { format: 'Listened' },
+            book: { id: 'ready-player-two-book', title: 'Ready Player Two' },
+          },
+        ]),
+        searchBooksByIsbn,
+        addBookToLibrary: mock.fn(),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:ready_player_two|ernest_cline',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          metadata: {
+            title: 'Ready Player Two: A Novel',
+            author: 'Ernest Cline',
+          },
+        },
+      },
+      { asin: '0593396960', isbn: null },
+      'Ready Player Two: A Novel',
+      'Ernest Cline',
+    );
+
+    assert.equal(result.editionId, 'ready-player-two-audio');
+    assert.equal(searchBooksByIsbn.mock.callCount(), 0);
+  });
+});

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -220,6 +220,74 @@ describe('Search-result auto-add guards', () => {
     assert.equal(match.edition.id, 30402186);
   });
 
+  it('reserves direct search-result additions before concurrent records can add the same work', async () => {
+    const syncExistingBook = mock.fn(async () => ({
+      status: 'completed',
+      reason: 'dry-run completion preview',
+    }));
+    const manager = Object.create(SyncManager.prototype);
+
+    Object.assign(manager, {
+      userId: 'test-user',
+      dryRun: true,
+      verbose: false,
+      timezone: 'UTC',
+      autoAddReservations: new Map(),
+      globalConfig: {
+        force_sync: true,
+        auto_add_books: true,
+        min_progress_threshold: 5,
+      },
+      bookMatcher: {
+        findMatch: mock.fn(async () => ({
+          match: createTwoStageMatch(),
+          extractedMetadata: {},
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_martian|andy_weir',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      hardcover: { addBookToLibrary: mock.fn() },
+      sessionManager: {
+        shouldDelayUpdate: mock.fn(async () => ({
+          shouldDelay: false,
+          reason: 'test sync',
+        })),
+        completeSession: mock.fn(async () => false),
+      },
+      _syncExistingBook: syncExistingBook,
+      _clearNegativeSyncSkip: mock.fn(async () => {}),
+    });
+    const createAbsBook = id => ({
+      id,
+      progress_percentage: 100,
+      media: {
+        metadata: {
+          title: 'The Martian',
+          authors: [{ name: 'Andy Weir' }],
+        },
+      },
+    });
+
+    const results = await Promise.all([
+      manager._syncSingleBook(createAbsBook('abs-standard'), null),
+      manager._syncSingleBook(createAbsBook('abs-full-cast'), null),
+    ]);
+
+    assert.deepEqual(
+      results.map(result => result.status).sort(),
+      ['completed', 'skipped'],
+    );
+    assert.equal(syncExistingBook.mock.callCount(), 1);
+    assert.equal(manager.autoAddReservations.size, 1);
+    assert.match(
+      results.find(result => result.status === 'skipped').reason,
+      /already reserved for auto-add/,
+    );
+  });
+
   it('caches the edition ID from a two-stage match', async () => {
     const storeEditionMapping = mock.fn(async () => {});
     const matcher = new TitleAuthorMatcher(null, { storeEditionMapping }, {});

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -148,6 +148,71 @@ describe('Search-result auto-add guards', () => {
     assert.equal(syncExistingBook.mock.callCount(), 1);
   });
 
+  it('continues a dry-run through the live post-add path without a second auto-add', async () => {
+    const match = createTwoStageMatch();
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+    const syncExistingBook = mock.fn(async () => ({
+      status: 'synced',
+      reason: 'dry-run sync preview',
+    }));
+    const manager = Object.create(SyncManager.prototype);
+
+    Object.assign(manager, {
+      userId: 'test-user',
+      dryRun: true,
+      verbose: false,
+      timezone: 'UTC',
+      globalConfig: {
+        force_sync: true,
+        auto_add_books: true,
+        min_progress_threshold: 5,
+      },
+      bookMatcher: {
+        findMatch: mock.fn(async () => ({
+          match,
+          extractedMetadata: {},
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_martian|andy_weir',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      hardcover: { addBookToLibrary },
+      sessionManager: {
+        shouldDelayUpdate: mock.fn(async () => ({
+          shouldDelay: false,
+          reason: 'dry-run sync preview',
+        })),
+        completeSession: mock.fn(async () => false),
+      },
+      _syncExistingBook: syncExistingBook,
+      _clearNegativeSyncSkip: mock.fn(async () => {}),
+    });
+
+    const result = await manager._syncSingleBook(
+      {
+        id: 'abs-the-martian',
+        progress_percentage: 100,
+        media: {
+          metadata: {
+            title: 'The Martian',
+            authors: [{ name: 'Andy Weir' }],
+          },
+        },
+      },
+      null,
+    );
+
+    assert.equal(result.status, 'synced');
+    assert.equal(addBookToLibrary.mock.callCount(), 0);
+    assert.equal(syncExistingBook.mock.callCount(), 1);
+    assert.equal(match._isSearchResult, false);
+    assert.equal(match.userBook.id, 'dry-run-292354');
+    assert.equal(match.userBook.book.id, 292354);
+    assert.equal(match.edition.id, 30402186);
+  });
+
   it('caches the edition ID from a two-stage match', async () => {
     const storeEditionMapping = mock.fn(async () => {});
     const matcher = new TitleAuthorMatcher(null, { storeEditionMapping }, {});

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -151,9 +151,12 @@ describe('Search-result auto-add guards', () => {
   it('continues a dry-run through the live post-add path without a second auto-add', async () => {
     const match = createTwoStageMatch();
     const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
-    const syncExistingBook = mock.fn(async () => ({
-      status: 'synced',
-      reason: 'dry-run sync preview',
+    const getBookCurrentProgress = mock.fn(async () => ({
+      has_progress: true,
+    }));
+    const handleCompletionStatus = mock.fn(async () => ({
+      status: 'completed',
+      reason: 'dry-run completion preview',
     }));
     const manager = Object.create(SyncManager.prototype);
 
@@ -177,8 +180,9 @@ describe('Search-result auto-add guards', () => {
         generateTitleAuthorIdentifier: () =>
           'title_author:the_martian|andy_weir',
         getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+        getSyncTracking: mock.fn(async () => ({ total_syncs: 2 })),
       },
-      hardcover: { addBookToLibrary },
+      hardcover: { addBookToLibrary, getBookCurrentProgress },
       sessionManager: {
         shouldDelayUpdate: mock.fn(async () => ({
           shouldDelay: false,
@@ -186,7 +190,8 @@ describe('Search-result auto-add guards', () => {
         })),
         completeSession: mock.fn(async () => false),
       },
-      _syncExistingBook: syncExistingBook,
+      _selectEditionWithCache: mock.fn(async () => match.edition),
+      _handleCompletionStatus: handleCompletionStatus,
       _clearNegativeSyncSkip: mock.fn(async () => {}),
     });
 
@@ -204,10 +209,12 @@ describe('Search-result auto-add guards', () => {
       null,
     );
 
-    assert.equal(result.status, 'synced');
+    assert.equal(result.status, 'completed');
     assert.equal(addBookToLibrary.mock.callCount(), 0);
-    assert.equal(syncExistingBook.mock.callCount(), 1);
+    assert.equal(getBookCurrentProgress.mock.callCount(), 0);
+    assert.equal(handleCompletionStatus.mock.callCount(), 1);
     assert.equal(match._isSearchResult, false);
+    assert.equal(match._isDryRunSimulatedAdd, true);
     assert.equal(match.userBook.id, 'dry-run-292354');
     assert.equal(match.userBook.book.id, 292354);
     assert.equal(match.edition.id, 30402186);

--- a/tests/startup-cache-path.test.js
+++ b/tests/startup-cache-path.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+
+describe('Startup cache path', () => {
+  it('uses the same shared cache for session recovery and normal syncs', () => {
+    const mainSource = readFileSync('./src/main.js', 'utf8');
+    const syncManagerSource = readFileSync('./src/sync-manager.js', 'utf8');
+
+    assert.match(
+      mainSource,
+      /processStartupSessions[\s\S]*?const cache = new BookCache\(\);/,
+    );
+    assert.match(syncManagerSource, /this\.cache = new BookCache\(\);/);
+    assert.doesNotMatch(mainSource, /\.book_cache_\$\{user\.id\}\.db/);
+  });
+});

--- a/tests/sync-manager-dry-run-isbn-search.test.js
+++ b/tests/sync-manager-dry-run-isbn-search.test.js
@@ -71,4 +71,67 @@ describe('SyncManager dry-run ISBN search', () => {
     assert.equal(searchBooksByIsbn.mock.calls[0].arguments[0], isbn);
     assert.equal(addBookToLibrary.mock.callCount(), 0);
   });
+
+  it('uses read-only title/author fallback results in dry-run mode', async () => {
+    const title = 'New Spring';
+    const findMatchByTitleAuthor = mock.fn(async () => ({
+      userBook: null,
+      book: { id: 'hardcover-book-new-spring', title },
+      edition: {
+        id: 'hardcover-edition-new-spring',
+        book: { id: 'hardcover-book-new-spring', title },
+        audio_seconds: 43740,
+        reading_format: { format: 'Listened' },
+      },
+      _matchType: 'title_author_two_stage',
+      _isSearchResult: true,
+    }));
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      hardcoverBooks: [],
+      globalConfig: { force_sync: false },
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => []),
+        searchBooksByIsbn: mock.fn(async () => []),
+        addBookToLibrary,
+      },
+      bookMatcher: { findMatchByTitleAuthor },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:new_spring|robert_jordan',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        id: 'abs-new-spring',
+        media: {
+          metadata: {
+            title,
+            author: 'Robert Jordan',
+            asin: 'B072325KCX',
+          },
+        },
+      },
+      { asin: 'B072325KCX', isbn: null },
+      title,
+      'Robert Jordan',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'hardcover-book-new-spring');
+    assert.equal(result.editionId, 'hardcover-edition-new-spring');
+    assert.equal(findMatchByTitleAuthor.mock.callCount(), 1);
+    assert.equal(addBookToLibrary.mock.callCount(), 0);
+  });
 });

--- a/tests/sync-result-auto-add-reporting.test.js
+++ b/tests/sync-result-auto-add-reporting.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { SyncResultFormatter } from '../src/display/SyncResultFormatter.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Post-add sync reporting', () => {
+  it('counts a simulated add that continues to completion without double-counting updated books', () => {
+    const manager = Object.create(SyncManager.prototype);
+    const result = {
+      books_processed: 0,
+      books_synced: 0,
+      books_completed: 0,
+      books_auto_added: 0,
+      books_skipped: 0,
+      books_delayed: 0,
+      errors: [],
+      book_details: [],
+    };
+
+    manager._updateResult(result, {
+      title: 'Ready Player Two',
+      status: 'completed',
+      actions: ['[DRY RUN] Would add matched book to library'],
+      errors: [],
+    });
+
+    assert.equal(result.books_processed, 1);
+    assert.equal(result.books_completed, 1);
+    assert.equal(result.books_auto_added, 1);
+
+    const formatter = new SyncResultFormatter();
+    const output = formatter._buildHardcoverUpdatesColumn(result, {
+      dry_run: true,
+    });
+    assert.ok(output.includes('├─ 1 would be updated'));
+  });
+});

--- a/tests/sync-result-auto-add-reporting.test.js
+++ b/tests/sync-result-auto-add-reporting.test.js
@@ -34,5 +34,14 @@ describe('Post-add sync reporting', () => {
       dry_run: true,
     });
     assert.ok(output.includes('├─ 1 would be updated'));
+
+    const liveOutput = formatter._buildHardcoverUpdatesColumn(result, {
+      dry_run: false,
+    });
+    assert.ok(liveOutput.includes('├─ 1 book updated'));
+    assert.equal(
+      liveOutput.some(line => line.includes('API calls made')),
+      false,
+    );
   });
 });

--- a/tests/title-author-stage-two-edition.test.js
+++ b/tests/title-author-stage-two-edition.test.js
@@ -6,9 +6,14 @@ import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matc
 const author = 'TheFirstDefier, JF Brink';
 
 function createAbsBook(number, duration) {
+  const numberedTitle = number ? ` ${number}` : '';
+  const title = `Defiance of the Fall${numberedTitle}: A LitRPG Adventure`;
   return {
-    id: `abs-defiance-${number}`,
-    title: `Defiance of the Fall ${number}: A LitRPG Adventure`,
+    id: `abs-defiance-${number || 1}`,
+    title:
+      number === 5
+        ? `${title} (Defiance of the Fall, Book 5)`
+        : title,
     author,
     narrator: 'Pavi Proczko',
     duration,
@@ -16,17 +21,22 @@ function createAbsBook(number, duration) {
   };
 }
 
-function createMatcher(absBook, bookDetails) {
+function searchResult(book) {
+  return {
+    id: book.id,
+    title: book.title,
+    contributions: (book.authors || []).map(name => ({ author: { name } })),
+    users_count: book.usersCount,
+    ratings_count: book.ratingsCount,
+  };
+}
+
+function createMatcher({ absBook, combinedResults, canonicalResults, books }) {
   const hardcoverClient = {
-    searchBooksForMatching: mock.fn(async () => [
-      {
-        id: bookDetails.id,
-        title: absBook.title,
-        author_names: [author],
-        activity: 100,
-      },
-    ]),
-    getBookDetailsWithEditions: mock.fn(async () => bookDetails),
+    searchBooksForMatching: mock.fn(async (_title, searchAuthor) =>
+      (searchAuthor ? combinedResults : canonicalResults).map(searchResult),
+    ),
+    getBookDetailsWithEditions: mock.fn(async bookId => books.get(bookId)),
   };
   const cache = {
     generateTitleAuthorIdentifier: (title, bookAuthor) =>
@@ -48,44 +58,190 @@ function createMatcher(absBook, bookDetails) {
 
 describe('Title/author Stage 2 edition selection', () => {
   for (const example of [
-    { number: 2, bookId: 2636424, editionId: 32941995, duration: 88226.78 },
-    { number: 3, bookId: 2636426, editionId: 32941997, duration: 82104.4 },
-    { number: 5, bookId: 2636422, editionId: 32941991, duration: 87120.2 },
+    {
+      number: 2,
+      duplicateBookId: 2636424,
+      duplicateEditionId: 32941995,
+      canonicalBookId: 545671,
+      canonicalEditionId: 31145800,
+      duration: 88226.78,
+      editionDuration: 88200,
+    },
+    {
+      number: 3,
+      duplicateBookId: 2636426,
+      duplicateEditionId: 32941997,
+      canonicalBookId: 545669,
+      canonicalEditionId: 31855844,
+      duration: 88440,
+      editionDuration: 88440,
+    },
+    {
+      number: 5,
+      duplicateBookId: 2636422,
+      duplicateEditionId: 32941991,
+      canonicalBookId: 637820,
+      canonicalEditionId: 31862655,
+      duration: 87120.2,
+      editionDuration: 87060,
+    },
   ]) {
-    it(`keeps Defiance of the Fall ${example.number} matched when the identified work only has a Read edition`, async () => {
+    it(`expands Defiance of the Fall ${example.number} to the canonical work with a Listened edition`, async () => {
       const absBook = createAbsBook(example.number, example.duration);
-      const { hardcoverClient, matcher } = createMatcher(absBook, {
-        id: example.bookId,
-        title: absBook.title,
+      const duplicateBook = {
+        id: example.duplicateBookId,
+        title: absBook.title.replace(/ \(Defiance.*$/, ''),
+        authors: [],
+        usersCount: example.number === 2 ? 1 : 0,
         editions: [
           {
-            id: example.editionId,
+            id: example.duplicateEditionId,
             reading_format: { format: 'Read' },
             pages: 700,
-            score: 280,
             users_count: 0,
           },
         ],
+      };
+      const canonicalBook = {
+        id: example.canonicalBookId,
+        title: `Defiance of the Fall ${example.number}`,
+        authors: ['TheFirstDefier'],
+        usersCount: 200,
+        ratingsCount: 100,
+        editions: [
+          {
+            id: example.canonicalEditionId,
+            asin: `canonical-asin-${example.number}`,
+            reading_format: { format: 'Listened' },
+            audio_seconds: example.editionDuration,
+            users_count: 8,
+            contributions: [
+              {
+                contribution: 'Narrator',
+                author: { name: 'Pavi Proczko' },
+              },
+            ],
+          },
+        ],
+      };
+      const { hardcoverClient, matcher } = createMatcher({
+        absBook,
+        combinedResults: [duplicateBook],
+        canonicalResults: [canonicalBook, duplicateBook],
+        books: new Map([
+          [duplicateBook.id, duplicateBook],
+          [canonicalBook.id, canonicalBook],
+        ]),
       });
 
       const result = await matcher.findMatch(absBook, 'test-user');
 
-      assert.equal(result.book.id, example.bookId);
-      assert.equal(result.edition.id, example.editionId);
-      assert.equal(result.edition.format, 'Read');
-      assert.ok(result._bookIdentificationScore.totalScore >= 70);
+      assert.equal(result.book.id, example.canonicalBookId);
+      assert.equal(result.edition.id, example.canonicalEditionId);
+      assert.equal(result.edition.format, 'Listened');
+      assert.equal(
+        result._bookIdentificationScore.strongIdentityEvidence.matches,
+        true,
+      );
+      assert.equal(
+        matcher.config.title_author_matching.confidence_threshold,
+        0.7,
+      );
+      assert.equal(
+        hardcoverClient.searchBooksForMatching.mock.callCount(),
+        2,
+      );
+      assert.equal(
+        hardcoverClient.searchBooksForMatching.mock.calls[1].arguments[0],
+        `defiance of the fall ${example.number}`,
+      );
+      assert.equal(
+        hardcoverClient.searchBooksForMatching.mock.calls[1].arguments[1],
+        null,
+      );
       assert.equal(
         hardcoverClient.getBookDetailsWithEditions.mock.callCount(),
-        1,
+        2,
+      );
+      assert.equal(
+        hardcoverClient.getBookDetailsWithEditions.mock.calls[0].arguments[0],
+        example.duplicateBookId,
+      );
+      assert.equal(
+        hardcoverClient.getBookDetailsWithEditions.mock.calls[1].arguments[0],
+        example.canonicalBookId,
       );
     });
   }
 
+  it('recovers unnumbered Defiance book 1 after unsafe combined-search results', async () => {
+    const absBook = createAbsBook(null, 84609.8);
+    const unsafeResults = [15, 17].map(number => ({
+      id: `defiance-${number}`,
+      title: `Defiance of the Fall ${number}`,
+      authors: ['TheFirstDefier', 'JF Brink'],
+      usersCount: number === 15 ? 82 : 18,
+      editions: [],
+    }));
+    const canonicalBook = {
+      id: 545665,
+      title: 'Defiance of the Fall',
+      authors: ['TheFirstDefier'],
+      usersCount: 396,
+      ratingsCount: 172,
+      editions: [
+        {
+          id: 31145227,
+          asin: 'B094JZYWLG',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 84540,
+          users_count: 8,
+          contributions: [
+            {
+              contribution: 'Narrator',
+              author: { name: 'Pavi Proczko' },
+            },
+          ],
+        },
+      ],
+    };
+    const { hardcoverClient, matcher } = createMatcher({
+      absBook,
+      combinedResults: unsafeResults,
+      canonicalResults: [canonicalBook, ...unsafeResults],
+      books: new Map([[canonicalBook.id, canonicalBook]]),
+    });
+
+    const result = await matcher.findMatch(absBook, 'test-user');
+
+    assert.equal(result.book.id, 545665);
+    assert.equal(result.edition.id, 31145227);
+    assert.equal(result.edition.format, 'Listened');
+    assert.equal(
+      result._bookIdentificationScore.strongIdentityEvidence.matches,
+      true,
+    );
+    assert.equal(
+      matcher.config.title_author_matching.confidence_threshold,
+      0.7,
+    );
+    assert.equal(
+      hardcoverClient.searchBooksForMatching.mock.calls[1].arguments[0],
+      'defiance of the fall',
+    );
+    assert.equal(
+      hardcoverClient.getBookDetailsWithEditions.mock.callCount(),
+      1,
+    );
+  });
+
   it('selects the duration-matched Listened edition for Defiance of the Fall 4', async () => {
     const absBook = createAbsBook(4, 82050.72);
-    const { matcher } = createMatcher(absBook, {
+    const canonicalBook = {
       id: 545679,
       title: 'Defiance of the Fall 4',
+      authors: ['TheFirstDefier'],
+      usersCount: 235,
       editions: [
         {
           id: 31476151,
@@ -109,6 +265,12 @@ describe('Title/author Stage 2 edition selection', () => {
           users_count: 100000,
         },
       ],
+    };
+    const { hardcoverClient, matcher } = createMatcher({
+      absBook,
+      combinedResults: [canonicalBook],
+      canonicalResults: [],
+      books: new Map([[canonicalBook.id, canonicalBook]]),
     });
 
     const result = await matcher.findMatch(absBook, 'test-user');
@@ -120,6 +282,17 @@ describe('Title/author Stage 2 edition selection', () => {
       result._editionSelectionResult.selectionReason.duration.score,
       100,
     );
-    assert.ok(result._bookIdentificationScore.totalScore >= 70);
+    assert.equal(
+      result._bookIdentificationScore.strongIdentityEvidence.matches,
+      true,
+    );
+    assert.equal(
+      matcher.config.title_author_matching.confidence_threshold,
+      0.7,
+    );
+    assert.equal(
+      hardcoverClient.searchBooksForMatching.mock.callCount(),
+      1,
+    );
   });
 });

--- a/tests/title-author-stage-two-edition.test.js
+++ b/tests/title-author-stage-two-edition.test.js
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matcher.js';
+
+const author = 'TheFirstDefier, JF Brink';
+
+function createAbsBook(number, duration) {
+  return {
+    id: `abs-defiance-${number}`,
+    title: `Defiance of the Fall ${number}: A LitRPG Adventure`,
+    author,
+    narrator: 'Pavi Proczko',
+    duration,
+    mediaType: 'audiobook',
+  };
+}
+
+function createMatcher(absBook, bookDetails) {
+  const hardcoverClient = {
+    searchBooksForMatching: mock.fn(async () => [
+      {
+        id: bookDetails.id,
+        title: absBook.title,
+        author_names: [author],
+        activity: 100,
+      },
+    ]),
+    getBookDetailsWithEditions: mock.fn(async () => bookDetails),
+  };
+  const cache = {
+    generateTitleAuthorIdentifier: (title, bookAuthor) =>
+      `title_author:${title.toLowerCase()}|${bookAuthor.toLowerCase()}`,
+    getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+    storeEditionMapping: mock.fn(async () => {}),
+  };
+
+  return {
+    hardcoverClient,
+    matcher: new TitleAuthorMatcher(hardcoverClient, cache, {
+      title_author_matching: {
+        confidence_threshold: 0.7,
+        max_search_results: 5,
+      },
+    }),
+  };
+}
+
+describe('Title/author Stage 2 edition selection', () => {
+  for (const example of [
+    { number: 2, bookId: 2636424, editionId: 32941995, duration: 88226.78 },
+    { number: 3, bookId: 2636426, editionId: 32941997, duration: 82104.4 },
+    { number: 5, bookId: 2636422, editionId: 32941991, duration: 87120.2 },
+  ]) {
+    it(`keeps Defiance of the Fall ${example.number} matched when the identified work only has a Read edition`, async () => {
+      const absBook = createAbsBook(example.number, example.duration);
+      const { hardcoverClient, matcher } = createMatcher(absBook, {
+        id: example.bookId,
+        title: absBook.title,
+        editions: [
+          {
+            id: example.editionId,
+            reading_format: { format: 'Read' },
+            pages: 700,
+            score: 280,
+            users_count: 0,
+          },
+        ],
+      });
+
+      const result = await matcher.findMatch(absBook, 'test-user');
+
+      assert.equal(result.book.id, example.bookId);
+      assert.equal(result.edition.id, example.editionId);
+      assert.equal(result.edition.format, 'Read');
+      assert.ok(result._bookIdentificationScore.totalScore >= 70);
+      assert.equal(
+        hardcoverClient.getBookDetailsWithEditions.mock.callCount(),
+        1,
+      );
+    });
+  }
+
+  it('selects the duration-matched Listened edition for Defiance of the Fall 4', async () => {
+    const absBook = createAbsBook(4, 82050.72);
+    const { matcher } = createMatcher(absBook, {
+      id: 545679,
+      title: 'Defiance of the Fall 4',
+      editions: [
+        {
+          id: 31476151,
+          reading_format: { format: 'Listened' },
+          audio_seconds: 40000,
+          score: 1900,
+          users_count: 100,
+        },
+        {
+          id: 32201823,
+          reading_format: { format: 'Listened' },
+          audio_seconds: 82050,
+          score: 1570,
+          users_count: 0,
+        },
+        {
+          id: 99999999,
+          reading_format: { format: 'Read' },
+          pages: 700,
+          score: 2000,
+          users_count: 100000,
+        },
+      ],
+    });
+
+    const result = await matcher.findMatch(absBook, 'test-user');
+
+    assert.equal(result.book.id, 545679);
+    assert.equal(result.edition.id, 32201823);
+    assert.equal(result.edition.format, 'Listened');
+    assert.equal(
+      result._editionSelectionResult.selectionReason.duration.score,
+      100,
+    );
+    assert.ok(result._bookIdentificationScore.totalScore >= 70);
+  });
+});

--- a/tests/title-author-strong-identity.test.js
+++ b/tests/title-author-strong-identity.test.js
@@ -208,6 +208,70 @@ describe('Strong title/author identity evidence', () => {
     assert.ok(score.totalScore < 70);
   });
 
+  for (const source of ['The Sandman: Act II', 'The Sandman: Act III']) {
+    it(`rejects the base Sandman work for ${source}`, () => {
+      const score = calculateBookIdentificationScore(
+        searchResult('The Sandman', ['Neil Gaiman', 'Dirk Maggs']),
+        source,
+        'Neil Gaiman, Dirk Maggs',
+      );
+
+      assert.equal(score.strongIdentityEvidence.canonicalTitleMatch, true);
+      assert.equal(score.strongIdentityEvidence.safeCanonicalTitleMatch, false);
+      assert.equal(score.strongIdentityEvidence.matches, false);
+      assert.ok(score.totalScore < 70);
+    });
+  }
+
+  it('rejects an arbitrary separator-truncated sequel title', () => {
+    const score = calculateBookIdentificationScore(
+      searchResult('Dune', ['Frank Herbert']),
+      'Dune: Messiah',
+      'Frank Herbert',
+    );
+
+    assert.equal(score.strongIdentityEvidence.canonicalTitleMatch, true);
+    assert.equal(score.strongIdentityEvidence.safeCanonicalTitleMatch, false);
+    assert.equal(score.strongIdentityEvidence.matches, false);
+    assert.ok(score.totalScore < 70);
+  });
+
+  it('does not select or cache the base Sandman work for Act II', async () => {
+    const baseWork = searchResult('The Sandman', [
+      'Neil Gaiman',
+      'Dirk Maggs',
+    ]);
+    const hardcoverClient = {
+      searchBooksForMatching: mock.fn(async () => [baseWork]),
+      getBookDetailsWithEditions: mock.fn(),
+    };
+    const cache = {
+      generateTitleAuthorIdentifier: () => 'title-author-key',
+      getCachedBookInfo: mock.fn(async () => null),
+      storeEditionMapping: mock.fn(async () => true),
+    };
+    const matcher = new TitleAuthorMatcher(hardcoverClient, cache, {
+      title_author_matching: { confidence_threshold: 0.7 },
+    });
+
+    const match = await matcher.findMatch(
+      {
+        title: 'The Sandman: Act II',
+        author: 'Neil Gaiman, Dirk Maggs',
+      },
+      'test-user',
+      () => null,
+      () => null,
+    );
+
+    assert.equal(match, null);
+    assert.equal(cache.storeEditionMapping.mock.callCount(), 0);
+    assert.equal(
+      hardcoverClient.getBookDetailsWithEditions.mock.callCount(),
+      0,
+    );
+  });
+
   it('selects a lower-scoring exact title instead of a higher-scoring unsafe candidate', async () => {
     const unsafe = searchResult('Fourth Wing, Iron Flame', [
       'Rebecca Yarros',

--- a/tests/title-author-strong-identity.test.js
+++ b/tests/title-author-strong-identity.test.js
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { calculateBookIdentificationScore } from '../src/matching/scoring/book-identification-scorer.js';
+import { TitleAuthorMatcher } from '../src/matching/strategies/title-author-matcher.js';
+
+function searchResult(title, authors = []) {
+  return {
+    id: `book-${title}`,
+    title,
+    contributions: authors.map(name => ({ author: { name } })),
+  };
+}
+
+const observedSafeMatches = [
+  {
+    source: 'Defiance of the Fall 2: A LitRPG Adventure',
+    candidate: 'Defiance of the Fall 2: A LitRPG Adventure',
+    author: 'TheFirstDefier, JF Brink',
+    candidateAuthors: [],
+  },
+  {
+    source: 'Defiance of the Fall 3: A LitRPG Adventure',
+    candidate: 'Defiance of the Fall 3: A LitRPG Adventure',
+    author: 'TheFirstDefier, JF Brink',
+    candidateAuthors: [],
+  },
+  {
+    source: 'Defiance of the Fall 4: A LitRPG Adventure',
+    candidate: 'Defiance of the Fall 4',
+    author: 'TheFirstDefier, JF Brink',
+    candidateAuthors: ['TheFirstDefier'],
+  },
+  {
+    source:
+      'Defiance of the Fall 5: A LitRPG Adventure (Defiance of the Fall, Book 5)',
+    candidate: 'Defiance of the Fall 5: A LitRPG Adventure',
+    author: 'TheFirstDefier, JF Brink',
+    candidateAuthors: [],
+  },
+  {
+    source: 'He Who Fights with Monsters 12: A LitRPG Adventure: He Who Fights with Monsters, Book 12',
+    candidate: 'He Who Fights with Monsters 12',
+    author: 'Shirtaloon, Travis Deverell',
+    candidateAuthors: ['Shirtaloon', 'Travis Deverell'],
+  },
+  {
+    source:
+      'He Who Fights with Monsters 4: A LitRPG Adventure (He Who Fights with Monsters, Book 4)',
+    candidate: 'He Who Fights with Monsters 4',
+    author: 'Shirtaloon, Travis Deverell',
+    candidateAuthors: ['Shirtaloon', 'Travis Deverell'],
+  },
+  {
+    source:
+      'He Who Fights with Monsters 9: A LitRPG Adventure (He Who Fights with Monsters, Book 9)',
+    candidate: 'He Who Fights With Monsters 9',
+    author: 'Shirtaloon, Travis Deverell',
+    candidateAuthors: ['Shirtaloon', 'Travis Deverell'],
+  },
+  {
+    source:
+      'He Who Fights with Monsters 11: A LitRPG Adventure: He Who Fights with Monsters, Book 11',
+    candidate: 'He Who Fights with Monsters 11',
+    author: 'Shirtaloon, Travis Deverell',
+    candidateAuthors: ['Shirtaloon', 'Travis Deverell'],
+  },
+  {
+    source: 'New Spring: The Wheel of Time Prequel',
+    candidate: 'New Spring',
+    author: 'Robert Jordan',
+    candidateAuthors: ['Robert Jordan'],
+  },
+  {
+    source: 'The Way of Kings: The Stormlight Archive, Book 1',
+    candidate: 'The Way of Kings',
+    author: 'Brandon Sanderson',
+    candidateAuthors: ['Brandon Sanderson'],
+  },
+  {
+    source: 'The Bands of Mourning (1 of 2): Mistborn Book 6',
+    candidate: 'The Bands of Mourning',
+    author: 'Brandon Sanderson, Graphic Audio',
+    candidateAuthors: ['Brandon Sanderson'],
+  },
+  {
+    source: "The Emperor's Soul [Dramatized Adaptation]: Elantris",
+    candidate: "The Emperor's Soul",
+    author: 'Brandon Sanderson',
+    candidateAuthors: ['Brandon Sanderson'],
+  },
+  {
+    source: 'American Gods: The Tenth Anniversary Edition (A Full Cast Production)',
+    candidate: 'American Gods',
+    author: 'Neil Gaiman',
+    candidateAuthors: ['Neil Gaiman'],
+  },
+  {
+    source: 'The Sandman: Act III',
+    candidate: 'The Sandman: Act III',
+    author: 'Neil Gaiman, Dirk Maggs',
+    candidateAuthors: ['Neil Gaiman', 'Dirk Maggs', 'James McAvoy'],
+  },
+  {
+    source: 'The Sandman: Act II',
+    candidate: 'The Sandman: Act II',
+    author: 'Neil Gaiman, Dirk Maggs',
+    candidateAuthors: ['Dirk Maggs', 'Neil Gaiman', 'James McAvoy'],
+  },
+  {
+    source: 'The Sandman',
+    candidate: 'The Sandman',
+    author: 'Neil Gaiman, Dirk Maggs',
+    candidateAuthors: ['Neil Gaiman', 'Dirk Maggs', 'James McAvoy'],
+  },
+  {
+    source: 'Edgedancer: Stormlight Archive',
+    candidate: 'Edgedancer',
+    author: 'Brandon Sanderson',
+    candidateAuthors: ['Brandon Sanderson'],
+  },
+];
+
+describe('Strong title/author identity evidence', () => {
+  for (const example of observedSafeMatches) {
+    it(`accepts ${example.source} as ${example.candidate}`, () => {
+      const score = calculateBookIdentificationScore(
+        searchResult(example.candidate, example.candidateAuthors),
+        example.source,
+        example.author,
+      );
+
+      assert.equal(score.strongIdentityEvidence.matches, true);
+    });
+  }
+
+  it('keeps the configured threshold while accepting an exact Defiance title with missing author metadata', async () => {
+    const result = searchResult(
+      'Defiance of the Fall 2: A LitRPG Adventure',
+    );
+    const rawScore = calculateBookIdentificationScore(
+      result,
+      'Defiance of the Fall 2: A LitRPG Adventure',
+      'TheFirstDefier, JF Brink',
+    );
+    assert.ok(rawScore.totalScore < 70);
+
+    const hardcoverClient = {
+      searchBooksForMatching: mock.fn(async () => [result]),
+      getPreferredEditionFromBookId: mock.fn(async bookId => ({
+        bookId,
+        title: result.title,
+        edition: {
+          id: 'defiance-2-audio',
+          audio_seconds: 80400,
+          reading_format: { format: 'Listened' },
+        },
+      })),
+    };
+    const cache = {
+      generateTitleAuthorIdentifier: () => 'title-author-key',
+      getCachedBookInfo: mock.fn(async () => null),
+      storeEditionMapping: mock.fn(async () => true),
+    };
+    const matcher = new TitleAuthorMatcher(hardcoverClient, cache, {
+      title_author_matching: { confidence_threshold: 0.7 },
+    });
+
+    const match = await matcher.findMatch(
+      {
+        title: 'Defiance of the Fall 2: A LitRPG Adventure',
+        author: 'TheFirstDefier, JF Brink',
+        media: { duration: 80400 },
+      },
+      'test-user',
+      () => null,
+      () => null,
+    );
+
+    assert.equal(match.book.id, result.id);
+    assert.equal(match.edition.id, 'defiance-2-audio');
+  });
+
+  it('rejects a Fourth Wing multi-book candidate below the threshold', () => {
+    const score = calculateBookIdentificationScore(
+      searchResult('Fourth Wing, Iron Flame', ['Rebecca Yarros']),
+      'Fourth Wing: Empyrean, Book 1',
+      'Rebecca Yarros',
+    );
+
+    assert.equal(score.strongIdentityEvidence.matches, false);
+    assert.ok(score.totalScore < 70);
+  });
+
+  it('rejects Defiance book 15 for an unnumbered Defiance book 1 title', () => {
+    const score = calculateBookIdentificationScore(
+      searchResult('Defiance of the Fall 15', [
+        'TheFirstDefier',
+        'JF Brink',
+      ]),
+      'Defiance of the Fall: A LitRPG Adventure',
+      'TheFirstDefier, JF Brink',
+    );
+
+    assert.equal(score.strongIdentityEvidence.matches, false);
+    assert.ok(score.totalScore < 70);
+  });
+
+  it('selects a lower-scoring exact title instead of a higher-scoring unsafe candidate', async () => {
+    const unsafe = searchResult('Fourth Wing, Iron Flame', [
+      'Rebecca Yarros',
+    ]);
+    const correct = searchResult('Fourth Wing: Empyrean, Book 1');
+    const unsafeScore = calculateBookIdentificationScore(
+      unsafe,
+      'Fourth Wing: Empyrean, Book 1',
+      'Rebecca Yarros',
+    );
+    const correctScore = calculateBookIdentificationScore(
+      correct,
+      'Fourth Wing: Empyrean, Book 1',
+      'Rebecca Yarros',
+    );
+    assert.ok(unsafeScore.totalScore > correctScore.totalScore);
+    assert.equal(unsafeScore.strongIdentityEvidence.matches, false);
+    assert.equal(correctScore.strongIdentityEvidence.matches, true);
+
+    const hardcoverClient = {
+      searchBooksForMatching: mock.fn(async () => [unsafe, correct]),
+      getPreferredEditionFromBookId: mock.fn(async bookId => ({
+        bookId,
+        title: correct.title,
+        edition: {
+          id: 'fourth-wing-audio',
+          reading_format: { format: 'Listened' },
+        },
+      })),
+    };
+    const cache = {
+      generateTitleAuthorIdentifier: () => 'title-author-key',
+      getCachedBookInfo: mock.fn(async () => null),
+      storeEditionMapping: mock.fn(async () => true),
+    };
+    const matcher = new TitleAuthorMatcher(hardcoverClient, cache, {
+      title_author_matching: { confidence_threshold: 0.7 },
+    });
+
+    const match = await matcher.findMatch(
+      {
+        title: 'Fourth Wing: Empyrean, Book 1',
+        author: 'Rebecca Yarros',
+      },
+      'test-user',
+      () => null,
+      () => null,
+    );
+
+    assert.equal(match.book.id, correct.id);
+    assert.equal(match.edition.id, 'fourth-wing-audio');
+  });
+
+  it('rejects an exact title when the known author conflicts', () => {
+    const score = calculateBookIdentificationScore(
+      searchResult('American Gods', ['Unrelated Author']),
+      'American Gods',
+      'Neil Gaiman',
+    );
+
+    assert.equal(score.strongIdentityEvidence.matches, false);
+  });
+});

--- a/tests/title-author-strong-identity.test.js
+++ b/tests/title-author-strong-identity.test.js
@@ -147,14 +147,16 @@ describe('Strong title/author identity evidence', () => {
 
     const hardcoverClient = {
       searchBooksForMatching: mock.fn(async () => [result]),
-      getPreferredEditionFromBookId: mock.fn(async bookId => ({
-        bookId,
+      getBookDetailsWithEditions: mock.fn(async bookId => ({
+        id: bookId,
         title: result.title,
-        edition: {
-          id: 'defiance-2-audio',
-          audio_seconds: 80400,
-          reading_format: { format: 'Listened' },
-        },
+        editions: [
+          {
+            id: 'defiance-2-audio',
+            audio_seconds: 80400,
+            reading_format: { format: 'Listened' },
+          },
+        ],
       })),
     };
     const cache = {
@@ -227,13 +229,15 @@ describe('Strong title/author identity evidence', () => {
 
     const hardcoverClient = {
       searchBooksForMatching: mock.fn(async () => [unsafe, correct]),
-      getPreferredEditionFromBookId: mock.fn(async bookId => ({
-        bookId,
+      getBookDetailsWithEditions: mock.fn(async bookId => ({
+        id: bookId,
         title: correct.title,
-        edition: {
-          id: 'fourth-wing-audio',
-          reading_format: { format: 'Listened' },
-        },
+        editions: [
+          {
+            id: 'fourth-wing-audio',
+            reading_format: { format: 'Listened' },
+          },
+        ],
       })),
     };
     const cache = {


### PR DESCRIPTION
## Context

I found these issues while running repeated dry runs against my local Audiobookshelf/Hardcover setup and wanted to contribute the fixes so other users can benefit. The failures were related: valid audiobooks could be rejected or mapped to a poor edition, unsafe title reduction could select the wrong work, and dry-run/cache behavior did not always model the live sync path accurately.

This is a large diff, so it is split into 25 focused commits with regression coverage for each logical boundary.

## What changed

### 1. Harden book and identifier identity

- Accept 10-character numeric ASIN metadata. If an ASIN search returns nothing and the value is also a valid ISBN-10, retry it as an ISBN instead of dropping the identifier.
- Validate global ASIN/ISBN search results against the Audiobookshelf title before allowing them to bypass fuzzy matching. This rejects clearly unrelated titles and single-work-to-collection conflicts even when Hardcover has the identifier attached to the wrong record.
- Normalize Arabic, written, and Roman title numbers consistently, while applying an explicit mismatch penalty when two titles identify different numbered works.
- Add a stronger volume/part guard for markers such as `Volume`, `Vol.`, `Book`, `Part`, and `#`. Equivalent forms such as `Volume II` and `Vol. 2` remain compatible, while `Vol. 1` and `Vol. 9` are rejected.
- Strip known audiobook-only annotations such as `[Dramatized Adaptation]`, `(Unabridged)`, and `(Full Cast Production)` without erasing work identity.
- Limit separator-based canonical title reductions to recognizable metadata suffixes. This prevents titles such as `The Sandman: Act II` from being reduced to and cached as `The Sandman`.
- Add deterministic strong-identity evidence for exact titles and safe canonical titles with author support, plus distinctive exact titles whose Hardcover result omits author metadata. This is a separate guarded acceptance path; it does **not** lower the configured fuzzy confidence threshold.
- Classify candidates that were found but rejected separately from books that were not found, making failed-match reports actionable.

### 2. Improve candidate discovery and audiobook edition choice

- Keep the initial combined title/author search, then expand with a canonical title-only search only when no safe candidate is accepted or the accepted work has no preferred-format edition. Results are merged by Hardcover work ID and rescored.
- Read additional Hardcover activity fields so ambiguous canonical candidates can use actual search/popularity evidence.
- Treat identifier matches as work-level evidence when the exact ISBN/ASIN edition has the wrong format or lacks usable length data. Other editions are fetched only from that same work and rescored with the existing unified edition scorer.
- Prefer Hardcover `Listened` editions for Audiobookshelf audiobooks and rank all available listened editions by format, duration, narrator, popularity, completeness, and data quality.
- Preserve work identity ahead of duration: a duration mismatch does not reject an otherwise correct work, but duration selects the closest edition when the correct work offers alternatives.
- Extract audiobook duration from Audiobookshelf's aggregate media duration when present, or sum `media.audioFiles[].duration` when the standard item response omits the aggregate.
- Include edition `users_count` in the Hardcover query so edition popularity can participate in ranking.

Regression coverage includes numbered series, split-audio titles, audiobook annotations, unsafe sequel reductions, collection conflicts, missing author metadata, identifier-linked print/ebook editions, multiple listened editions, and the Defiance of the Fall 1–5 cases.

### 3. Align dry-run, auto-add, and concurrency behavior

- Let dry runs exercise the same title-fallback and post-add decision flow as live syncs, so completion/progress outcomes and summary counts can be validated without writing to Hardcover.
- Represent simulated additions only long enough to continue the dry-run control flow, then skip the live-only existing-progress lookup that requires a real integer Hardcover user-book ID. This removes synthetic-ID warnings without hiding any live mutation path.
- Reserve auto-adds by Hardcover work ID across concurrent workers in both matcher and direct-search paths.
- Make reservations outcome-aware: duplicate workers wait for the first attempt, skip after a successful add, and retry if the first add returns no result or throws. A successfully added work stays reserved even if later cache bookkeeping fails.
- Prevent duplicate records for the same work from being auto-added twice during one run.
- Count a dry-run post-add completion/progress result as one auto-added book rather than losing the add from the summary.

No Hardcover write is introduced in dry-run mode.

### 4. Make cache/session behavior consistent

Two small cache changes are included because the dry runs exposed behavior that otherwise looked unrelated:

- Startup session recovery previously opened `data/.book_cache_<user>.db`, while normal syncs write `data/.book_cache.db`. Recovery therefore looked in a different physical database and could not see the active sessions created by the sync manager. Startup now uses the same default `BookCache` path as normal syncs.
- The shared file does not make cache records cross-user: the cache schema, unique constraints, and lookups remain scoped by `user_id`. There is no schema change or cache-data merge; this only makes the startup reader use the database the normal writer already uses.
- SQLite transaction timeout handling now reads `busy_timeout` with better-sqlite3's scalar `{ simple: true }` form, applies the requested timeout, and restores the original value after the transaction.

### 5. Clarify reporting

- Report successful books updated rather than labeling a per-book success count as “API calls made”; one book can require several Hardcover mutations.
- Use detailed successful book rows when available so post-add progress/completion does not double-count a single book.

## Safety properties retained

- The configured matching threshold is unchanged.
- Deterministic identity evidence is guarded by title, author, collection, and explicit part/volume checks.
- Duration ranks editions within an identified work; it does not make a different work acceptable.
- Failed auto-adds are retryable, while successful adds remain deduplicated for the run.
- Dry-run mode performs no Hardcover mutations.

## Validation

- Supported Node 24 test runner: **595 passed, 0 failed** across 221 suites. The repository runner reports 18 existing known-failing files as quarantined.
- Focused rebase/conflict coverage: **29 passed, 0 failed**.
- ESLint: **passed** with zero warnings.
- `git diff --check`: **passed**.
- Prettier `--check`: currently reports style differences in 12 touched files. I left these unchanged rather than add a formatting-only commit across the functional changes.