### PR TITLE
fix(hardcover): stop progress sync after status update failure

### DIFF
--- a/src/hardcover-client.js
+++ b/src/hardcover-client.js
@@ -261,7 +261,15 @@ export class HardcoverClient {
           newStatus: 2,
         },
       );
-      await this.updateBookStatus(userBookId, 2);
+      const updatedBook = await this.updateBookStatus(userBookId, 2);
+      if (!updatedBook) {
+        logger.error('Failed to update book status before syncing progress', {
+          userBookId,
+          currentStatus: 1,
+          requestedStatus: 2,
+        });
+        return false;
+      }
       currentStatusId = 2;
       statusWasUpdated = true;
     }

--- a/tests/want-to-read-status-update.test.js
+++ b/tests/want-to-read-status-update.test.js
@@ -104,6 +104,38 @@ describe('HardcoverClient - Want to Read Status Update', () => {
         statusWasUpdated: true,
       });
     });
+
+    it('should not insert first progress when the status update fails', async () => {
+      const client = new HardcoverClient(mockToken);
+
+      client._executeQuery = mock.fn(async () => ({
+        user_book_reads: [],
+        user_books: [
+          {
+            id: mockUserBookId,
+            status_id: 1,
+          },
+        ],
+      }));
+      client.updateBookStatus = mock.fn(async () => false);
+      client.insertUserBookRead = mock.fn(async () => ({
+        id: mockReadId,
+        progress_seconds: mockCurrentProgress,
+      }));
+
+      const result = await client.updateReadingProgress(
+        mockUserBookId,
+        mockCurrentProgress,
+        mockProgressPercentage,
+        mockEditionId,
+        true,
+        '2024-01-01',
+      );
+
+      assert.equal(result, false);
+      assert.equal(client.updateBookStatus.mock.callCount(), 1);
+      assert.equal(client.insertUserBookRead.mock.callCount(), 0);
+    });
   });
 
   describe('updateReadingProgress - Status Transition Tests', () => {


### PR DESCRIPTION
## Summary

Prevent first-progress syncs from being cached as a successful status transition when Hardcover fails to move a book from Want to Read to Currently Reading. This is follow-up hardening for #227 and #228.

- Stop the progress write when the prerequisite status mutation returns no updated book.
- Log the failed transition with the user-book ID and requested status.
- Add regression coverage proving that first progress is not inserted after a failed status update, leaving the sync retryable.

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: N/A - no follow-up work is required.

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, failure handling only
- [ ] `template.env` updated if environment variables or example config changed — N/A, no configuration changes
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, no Unreleased section exists in the current changelog

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses the npm test runner
- [x] `npm test` — 533 passed, 0 failed
- [x] Focused test(s):
    - `node --test tests/want-to-read-status-update.test.js`
    - `node --test tests/want-to-read-edition-change-integration.test.js tests/status-update-backward-compatibility.test.js tests/sync-manager-first-sync-regression.test.js tests/hardcover-null-progress-repair.test.js`
- [x] `npm run lint`
- [x] `npm run format:check -- src/hardcover-client.js tests/want-to-read-status-update.test.js`

- [ ] Docker or Compose validation, if container behavior changed: N/A - no container behavior changed
