### PR TITLE
fix(matching): retry numeric ASINs as ISBN-10

### DIFF
--- a/src/matching/index.js
+++ b/src/matching/index.js
@@ -22,6 +22,7 @@ export {
   convertIsbn10To13,
   convertIsbn13To10,
   getIsbnVariants,
+  getIsbn10FromNumericAsin,
   normalizeAsin,
   normalizeTitle,
   normalizeAuthor,

--- a/src/matching/strategies/asin-matcher.js
+++ b/src/matching/strategies/asin-matcher.js
@@ -7,6 +7,7 @@
 
 import logger from '../../logger.js';
 import { extractTitle } from '../utils/audiobookshelf-extractor.js';
+import { getIsbn10FromNumericAsin } from '../utils/text-matching.js';
 
 /**
  * ASIN Matching Strategy - Tier 1
@@ -49,12 +50,27 @@ export class AsinMatcher {
 
         try {
           // Search Hardcover's global database for this ASIN
-          const searchResults = await this.hardcoverClient.searchBooksByAsin(
+          let searchMethod = 'asin';
+          let searchResults = await this.hardcoverClient.searchBooksByAsin(
             identifiers.asin,
           );
           logger.debug(
             `ASIN search returned ${searchResults.length} results for ${identifiers.asin}`,
           );
+
+          const numericAsinIsbn = getIsbn10FromNumericAsin(identifiers.asin);
+          if (
+            searchResults.length === 0 &&
+            numericAsinIsbn &&
+            this.hardcoverClient.searchBooksByIsbn
+          ) {
+            logger.debug(
+              `Retrying numeric ASIN ${identifiers.asin} as ISBN-10`,
+            );
+            searchResults =
+              await this.hardcoverClient.searchBooksByIsbn(numericAsinIsbn);
+            searchMethod = 'isbn';
+          }
 
           if (searchResults.length > 0) {
             // Check if we have any edition of the same book
@@ -101,7 +117,7 @@ export class AsinMatcher {
                   return {
                     userBook: existingUserBook,
                     edition: userEdition,
-                    _matchType: 'asin_cross_edition',
+                    _matchType: `${searchMethod}_cross_edition`,
                     _tier: 1,
                     _needsScoring: false,
                   };
@@ -124,7 +140,7 @@ export class AsinMatcher {
             return {
               userBook: null,
               edition: firstResult,
-              _matchType: 'asin_search_result',
+              _matchType: `${searchMethod}_search_result`,
               _tier: 1,
               _needsScoring: false,
               _needsBookIdLookup: true, // Book ID needs to be looked up from edition

--- a/src/matching/utils/text-matching.js
+++ b/src/matching/utils/text-matching.js
@@ -738,13 +738,6 @@ export function getIsbnVariants(isbn) {
 
 export function normalizeAsin(asin) {
   if (!asin) return null;
-  const normalized = asin.replace(/\s/g, '').toUpperCase();
-  if (
-    normalized.length === 10 &&
-    /^[A-Z]/.test(normalized) &&
-    !/^\d+$/.test(normalized)
-  ) {
-    return normalized;
-  }
-  return null;
+  const normalized = String(asin).replace(/\s/g, '').toUpperCase();
+  return /^[A-Z0-9]{10}$/.test(normalized) ? normalized : null;
 }

--- a/src/matching/utils/text-matching.js
+++ b/src/matching/utils/text-matching.js
@@ -741,3 +741,10 @@ export function normalizeAsin(asin) {
   const normalized = String(asin).replace(/\s/g, '').toUpperCase();
   return /^[A-Z0-9]{10}$/.test(normalized) ? normalized : null;
 }
+
+export function getIsbn10FromNumericAsin(asin) {
+  const normalized = normalizeAsin(asin);
+  if (!normalized || !/^\d{10}$/.test(normalized)) return null;
+
+  return convertIsbn10To13(normalized) ? normalized : null;
+}

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -9,6 +9,7 @@ import {
   extractAudioDurationFromAudiobookshelf,
   extractBookIdentifiers,
   extractTitle,
+  getIsbn10FromNumericAsin,
   getIsbnVariants,
 } from './matching/index.js';
 import { formatDurationForLogging } from './utils/time.js';
@@ -2472,7 +2473,31 @@ export class SyncManager {
         });
       }
 
-      if (searchResults.length === 0 && identifiers.isbn) {
+      const numericAsinIsbn = getIsbn10FromNumericAsin(identifiers.asin);
+      if (searchResults.length === 0 && numericAsinIsbn) {
+        logger.info(
+          `Searching Hardcover by ISBN-10 from numeric ASIN: ${numericAsinIsbn}`,
+          { dryRun: this.dryRun },
+        );
+        searchResults = await this.hardcover.searchBooksByIsbn(numericAsinIsbn);
+        logger.info(
+          `Numeric ASIN ISBN-10 search returned ${searchResults.length} results`,
+          {
+            dryRun: this.dryRun,
+            results: searchResults.map(r => ({
+              id: r.id,
+              format: r.reading_format?.format || r.physical_format,
+              title: r.book?.title,
+            })),
+          },
+        );
+      }
+
+      if (
+        searchResults.length === 0 &&
+        identifiers.isbn &&
+        identifiers.isbn !== numericAsinIsbn
+      ) {
         logger.info(`Searching Hardcover by ISBN: ${identifiers.isbn}`, {
           dryRun: this.dryRun,
         });

--- a/tests/numeric-asin-isbn-fallback.test.js
+++ b/tests/numeric-asin-isbn-fallback.test.js
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { AsinMatcher } from '../src/matching/strategies/asin-matcher.js';
+import {
+  getIsbn10FromNumericAsin,
+  normalizeAsin,
+} from '../src/matching/utils/text-matching.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Numeric ASIN ISBN-10 fallback', () => {
+  it('only treats valid numeric ISBN-10 values as fallback candidates', () => {
+    assert.equal(normalizeAsin('1250759781'), '1250759781');
+    assert.equal(getIsbn10FromNumericAsin('1250759781'), '1250759781');
+    assert.equal(getIsbn10FromNumericAsin('B082FQRWWR'), null);
+    assert.equal(getIsbn10FromNumericAsin('1250759782'), null);
+  });
+
+  it('retries a failed numeric ASIN lookup as ISBN-10 in AsinMatcher', async () => {
+    const searchBooksByAsin = mock.fn(async () => []);
+    const searchBooksByIsbn = mock.fn(async () => [
+      {
+        id: 'rhythm-audio',
+        isbn_10: '1250759781',
+        reading_format: { format: 'Listened' },
+        book: { id: 'rhythm-book', title: 'Rhythm of War' },
+      },
+    ]);
+    const matcher = new AsinMatcher({
+      searchBooksByAsin,
+      searchBooksByIsbn,
+    });
+
+    const result = await matcher.findMatch(
+      {
+        media: {
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+          },
+        },
+      },
+      { asin: '1250759781' },
+      {},
+      () => null,
+    );
+
+    assert.equal(result.edition.id, 'rhythm-audio');
+    assert.equal(result._matchType, 'isbn_search_result');
+    assert.equal(searchBooksByAsin.mock.callCount(), 1);
+    assert.equal(searchBooksByIsbn.mock.callCount(), 1);
+    assert.equal(searchBooksByIsbn.mock.calls[0].arguments[0], '1250759781');
+  });
+
+  it('prefers numeric-ASIN ISBN results over a separate ebook ISBN', async () => {
+    const searchBooksByIsbn = mock.fn(async isbn =>
+      isbn === '1250759781'
+        ? [
+            {
+              id: 'rhythm-audio',
+              isbn_10: isbn,
+              audio_seconds: 206760,
+              reading_format: { format: 'Listened' },
+              book: { id: 'rhythm-book', title: 'Rhythm of War' },
+            },
+          ]
+        : [
+            {
+              id: 'rhythm-ebook',
+              isbn_13: isbn,
+              reading_format: { format: 'Ebook' },
+              book: { id: 'rhythm-book', title: 'Rhythm of War' },
+            },
+          ],
+    );
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      globalConfig: { force_sync: false },
+      autoAddReservations: new Map(),
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => []),
+        searchBooksByIsbn,
+        addBookToLibrary: mock.fn(),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:rhythm_of_war|brandon_sanderson',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+      _getEditionProgressBasis: SyncManager.prototype._getEditionProgressBasis,
+      _isEditionProgressCapable:
+        SyncManager.prototype._isEditionProgressCapable,
+      _selectProgressCapableEdition:
+        SyncManager.prototype._selectProgressCapableEdition,
+      _resolveProgressCapableAutoAddEdition:
+        SyncManager.prototype._resolveProgressCapableAutoAddEdition,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          audioFiles: [{ duration: 206700 }],
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: '1250759781', isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.editionId, 'rhythm-audio');
+    assert.equal(searchBooksByIsbn.mock.callCount(), 1);
+    assert.equal(searchBooksByIsbn.mock.calls[0].arguments[0], '1250759781');
+  });
+
+  it('does not run ISBN fallback when a numeric ASIN already matches', async () => {
+    const searchBooksByIsbn = mock.fn(async () => []);
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      globalConfig: { force_sync: false },
+      autoAddReservations: new Map(),
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => [
+          {
+            id: 'ready-player-two-audio',
+            asin: '0593396960',
+            audio_seconds: 1,
+            reading_format: { format: 'Listened' },
+            book: { id: 'ready-player-two-book', title: 'Ready Player Two' },
+          },
+        ]),
+        searchBooksByIsbn,
+        addBookToLibrary: mock.fn(),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:ready_player_two|ernest_cline',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+      _getEditionProgressBasis: SyncManager.prototype._getEditionProgressBasis,
+      _isEditionProgressCapable:
+        SyncManager.prototype._isEditionProgressCapable,
+      _selectProgressCapableEdition:
+        SyncManager.prototype._selectProgressCapableEdition,
+      _resolveProgressCapableAutoAddEdition:
+        SyncManager.prototype._resolveProgressCapableAutoAddEdition,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          metadata: {
+            title: 'Ready Player Two: A Novel',
+            author: 'Ernest Cline',
+          },
+        },
+      },
+      { asin: '0593396960', isbn: null },
+      'Ready Player Two: A Novel',
+      'Ernest Cline',
+    );
+
+    assert.equal(result.editionId, 'ready-player-two-audio');
+    assert.equal(searchBooksByIsbn.mock.callCount(), 0);
+  });
+});


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It preserves numeric ASIN metadata and retries ten-digit numeric ASINs as ISBN-10 identifiers during matching and sync.

- accept numeric Audiobookshelf ASIN metadata
- retry numeric ASINs through Hardcover's ISBN-10 lookup path
- add focused matching and sync regression coverage
- Related: #168

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/numeric-asin-isbn-fallback.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A
