### PR TITLE
fix(matching): rank listened audiobook editions

### DIFF
--- a/src/matching/utils/audiobookshelf-extractor.js
+++ b/src/matching/utils/audiobookshelf-extractor.js
@@ -511,6 +511,21 @@ export function extractAudioDurationFromAudiobookshelf(bookData) {
         return bookData.media[field];
       }
     }
+
+    // Standard (non-expanded) Audiobookshelf item responses omit
+    // media.duration but retain duration on each audio file.
+    if (Array.isArray(bookData.media.audioFiles)) {
+      const audioFileDuration = bookData.media.audioFiles.reduce(
+        (total, audioFile) => {
+          const duration = Number(audioFile?.duration);
+          return Number.isFinite(duration) && duration > 0
+            ? total + duration
+            : total;
+        },
+        0,
+      );
+      if (audioFileDuration > 0) return audioFileDuration;
+    }
   }
 
   // Check metadata object

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2501,7 +2501,7 @@ export class SyncManager {
 
         if (!hasCompatibleFormat) {
           logger.info(
-            `Format mismatch in identifier search for "${title}" - triggering title/author fallback`,
+            `Format mismatch in identifier search for "${title}" - checking other editions of the matched book`,
             {
               sourceFormat,
               identifiersSearched: {
@@ -2515,8 +2515,51 @@ export class SyncManager {
             },
           );
 
-          // Clear search results to trigger title/author fallback
-          searchResults = [];
+          const matchedBookIds = [
+            ...new Set(
+              searchResults.map(result => result.book?.id).filter(Boolean),
+            ),
+          ];
+          const compatibleEditions = [];
+
+          for (const bookId of matchedBookIds) {
+            const bookDetails =
+              await this.hardcover.getBookDetailsWithEditions(bookId);
+            if (!bookDetails?.editions) continue;
+
+            for (const edition of bookDetails.editions) {
+              const editionFormat = this._mapHardcoverFormatToInternal(edition);
+              if (this._areFormatsCompatible(sourceFormat, editionFormat)) {
+                compatibleEditions.push({
+                  ...edition,
+                  book: {
+                    id: bookDetails.id,
+                    title: bookDetails.title,
+                    contributions: bookDetails.contributions,
+                  },
+                });
+              }
+            }
+          }
+
+          if (compatibleEditions.length > 0) {
+            logger.info(
+              `Found compatible editions on identifier-matched book`,
+              {
+                title,
+                sourceFormat,
+                matchedBookIds,
+                compatibleEditionCount: compatibleEditions.length,
+              },
+            );
+            searchResults = compatibleEditions;
+          } else {
+            logger.info(
+              `No compatible edition found on identifier-matched book - triggering title/author fallback`,
+              { title, sourceFormat, matchedBookIds },
+            );
+            searchResults = [];
+          }
         }
       }
 
@@ -4292,17 +4335,15 @@ export class SyncManager {
       return true;
     }
 
-    // Audiobook and ebook are compatible (cross-digital)
-    if (
-      (sourceFormat === 'audiobook' && editionFormat === 'ebook') ||
-      (sourceFormat === 'ebook' && editionFormat === 'audiobook')
-    ) {
-      return true;
+    // An audiobook must use a listened edition so progress is recorded in
+    // seconds against the correct medium.
+    if (sourceFormat === 'audiobook') {
+      return false;
     }
 
-    // Physical edition ('book') is NOT compatible with audiobook
-    if (sourceFormat === 'audiobook' && editionFormat === 'book') {
-      return false;
+    // Ebook sources may still use an audiobook edition as a digital fallback.
+    if (sourceFormat === 'ebook' && editionFormat === 'audiobook') {
+      return true;
     }
 
     // Allow ebook → physical fallback (acceptable)

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2499,11 +2499,13 @@ export class SyncManager {
           sourceFormat,
         );
 
-        if (!hasCompatibleFormat) {
+        if (!hasCompatibleFormat || sourceFormat === 'audiobook') {
           logger.info(
-            `Format mismatch in identifier search for "${title}" - checking other editions of the matched book`,
+            `Checking other editions of the identifier-matched book`,
             {
+              title,
               sourceFormat,
+              identifierResultCompatible: hasCompatibleFormat,
               identifiersSearched: {
                 asin: identifiers.asin || 'N/A',
                 isbn: identifiers.isbn || 'N/A',
@@ -2522,22 +2524,25 @@ export class SyncManager {
           ];
           const compatibleEditions = [];
 
-          for (const bookId of matchedBookIds) {
-            const bookDetails =
-              await this.hardcover.getBookDetailsWithEditions(bookId);
-            if (!bookDetails?.editions) continue;
+          if (this.hardcover.getBookDetailsWithEditions) {
+            for (const bookId of matchedBookIds) {
+              const bookDetails =
+                await this.hardcover.getBookDetailsWithEditions(bookId);
+              if (!bookDetails?.editions) continue;
 
-            for (const edition of bookDetails.editions) {
-              const editionFormat = this._mapHardcoverFormatToInternal(edition);
-              if (this._areFormatsCompatible(sourceFormat, editionFormat)) {
-                compatibleEditions.push({
-                  ...edition,
-                  book: {
-                    id: bookDetails.id,
-                    title: bookDetails.title,
-                    contributions: bookDetails.contributions,
-                  },
-                });
+              for (const edition of bookDetails.editions) {
+                const editionFormat =
+                  this._mapHardcoverFormatToInternal(edition);
+                if (this._areFormatsCompatible(sourceFormat, editionFormat)) {
+                  compatibleEditions.push({
+                    ...edition,
+                    book: {
+                      id: bookDetails.id,
+                      title: bookDetails.title,
+                      contributions: bookDetails.contributions,
+                    },
+                  });
+                }
               }
             }
           }
@@ -2553,6 +2558,11 @@ export class SyncManager {
               },
             );
             searchResults = compatibleEditions;
+          } else if (hasCompatibleFormat) {
+            logger.info(
+              `Could not load other editions; keeping compatible identifier result`,
+              { title, sourceFormat, matchedBookIds },
+            );
           } else {
             logger.info(
               `No compatible edition found on identifier-matched book - triggering title/author fallback`,

--- a/tests/audiobookshelf-duration-extraction.test.js
+++ b/tests/audiobookshelf-duration-extraction.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { extractAudioDurationFromAudiobookshelf } from '../src/matching/utils/audiobookshelf-extractor.js';
+
+describe('Audiobookshelf duration extraction', () => {
+  it('sums audio-file durations from a standard item response', () => {
+    const duration = extractAudioDurationFromAudiobookshelf({
+      media: {
+        audioFiles: [
+          { duration: 1200.5 },
+          { duration: 1800.25 },
+          { duration: null },
+        ],
+      },
+    });
+
+    assert.equal(duration, 3000.75);
+  });
+
+  it('prefers the aggregate media duration when ABS supplies it', () => {
+    const duration = extractAudioDurationFromAudiobookshelf({
+      media: {
+        duration: 3000,
+        audioFiles: [{ duration: 2999.5 }],
+      },
+    });
+
+    assert.equal(duration, 3000);
+  });
+
+  it('returns null when no positive duration is available', () => {
+    const duration = extractAudioDurationFromAudiobookshelf({
+      media: {
+        audioFiles: [{ duration: 0 }, { duration: 'unknown' }],
+      },
+    });
+
+    assert.equal(duration, null);
+  });
+});

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -120,4 +120,45 @@ describe('Audiobook auto-add edition selection', () => {
     assert.equal(result.bookId, 'rhythm-book');
     assert.equal(result.editionId, 'different-duration-audiobook');
   });
+
+  it('uses summed ABS file duration to choose the closest audiobook edition', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'far-duration-audiobook',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 40000,
+          users_count: 10,
+        },
+        {
+          id: 'close-duration-audiobook',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 20500,
+          users_count: 10,
+        },
+      ],
+    });
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          audioFiles: [{ duration: 10000 }, { duration: 10000 }],
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(result.editionId, 'close-duration-audiobook');
+  });
 });

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -26,11 +26,16 @@ function createManager(bookDetails) {
         'title_author:rhythm_of_war|brandon_sanderson',
       getCachedBookInfo: mock.fn(async () => ({ exists: false })),
     },
-    _checkFormatCompatibility:
-      SyncManager.prototype._checkFormatCompatibility,
+    _checkFormatCompatibility: SyncManager.prototype._checkFormatCompatibility,
     _mapHardcoverFormatToInternal:
       SyncManager.prototype._mapHardcoverFormatToInternal,
     _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    _getEditionProgressBasis: SyncManager.prototype._getEditionProgressBasis,
+    _isEditionProgressCapable: SyncManager.prototype._isEditionProgressCapable,
+    _selectProgressCapableEdition:
+      SyncManager.prototype._selectProgressCapableEdition,
+    _resolveProgressCapableAutoAddEdition:
+      SyncManager.prototype._resolveProgressCapableAutoAddEdition,
   };
 }
 
@@ -210,9 +215,6 @@ describe('Audiobook auto-add edition selection', () => {
 
     assert.equal(result.status, 'auto_added');
     assert.equal(result.bookId, 'rhythm-book');
-    assert.equal(
-      result.editionId,
-      'different-identifier-close-audiobook',
-    );
+    assert.equal(result.editionId, 'different-identifier-close-audiobook');
   });
 });

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -161,4 +161,58 @@ describe('Audiobook auto-add edition selection', () => {
     assert.equal(result.bookId, 'rhythm-book');
     assert.equal(result.editionId, 'close-duration-audiobook');
   });
+
+  it('checks same-book editions when the identifier audiobook has the wrong duration', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'identifier-audiobook',
+          asin: 'B082FARAWAY',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 40000,
+          users_count: 10,
+        },
+        {
+          id: 'different-identifier-close-audiobook',
+          asin: 'B082CLOSER1',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 20500,
+          users_count: 10,
+        },
+      ],
+    });
+    manager.hardcover.searchBooksByIsbn = mock.fn(async () => [
+      {
+        id: 'identifier-audiobook',
+        reading_format: { format: 'Listened' },
+        audio_seconds: 40000,
+        book: { id: 'rhythm-book', title: 'Rhythm of War' },
+      },
+    ]);
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        media: {
+          audioFiles: [{ duration: 10000 }, { duration: 10000 }],
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(
+      result.editionId,
+      'different-identifier-close-audiobook',
+    );
+  });
 });

--- a/tests/auto-add-audiobook-edition-selection.test.js
+++ b/tests/auto-add-audiobook-edition-selection.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { SyncManager } from '../src/sync-manager.js';
+
+function createManager(bookDetails) {
+  return {
+    userId: 'test-user',
+    dryRun: true,
+    globalConfig: { force_sync: false },
+    hardcover: {
+      searchBooksByAsin: mock.fn(async () => []),
+      searchBooksByIsbn: mock.fn(async () => [
+        {
+          id: 'ebook-edition',
+          isbn_13: '9781429952040',
+          reading_format: { format: 'Ebook' },
+          book: { id: 'rhythm-book', title: 'Rhythm of War' },
+        },
+      ]),
+      getBookDetailsWithEditions: mock.fn(async () => bookDetails),
+      addBookToLibrary: mock.fn(),
+    },
+    cache: {
+      generateTitleAuthorIdentifier: () =>
+        'title_author:rhythm_of_war|brandon_sanderson',
+      getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+    },
+    _checkFormatCompatibility:
+      SyncManager.prototype._checkFormatCompatibility,
+    _mapHardcoverFormatToInternal:
+      SyncManager.prototype._mapHardcoverFormatToInternal,
+    _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+  };
+}
+
+describe('Audiobook auto-add edition selection', () => {
+  it('does not treat an ebook edition as audiobook-compatible', () => {
+    assert.equal(
+      SyncManager.prototype._areFormatsCompatible('audiobook', 'ebook'),
+      false,
+    );
+  });
+
+  it('keeps the identifier-matched book and selects its audiobook edition', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'ebook-edition',
+          reading_format: { format: 'Ebook' },
+          pages: 1213,
+        },
+        {
+          id: 'audiobook-edition',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 206760,
+          users_count: 50,
+        },
+      ],
+    });
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        duration: 190000,
+        media: {
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(result.editionId, 'audiobook-edition');
+    assert.equal(
+      manager.hardcover.getBookDetailsWithEditions.mock.callCount(),
+      1,
+    );
+    assert.equal(manager.hardcover.addBookToLibrary.mock.callCount(), 0);
+  });
+
+  it('keeps the correct book when its audiobook duration differs', async () => {
+    const manager = createManager({
+      id: 'rhythm-book',
+      title: 'Rhythm of War',
+      editions: [
+        {
+          id: 'different-duration-audiobook',
+          reading_format: { format: 'Listened' },
+          audio_seconds: 250000,
+        },
+      ],
+    });
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        duration: 190000,
+        media: {
+          metadata: {
+            title: 'Rhythm of War: Book Four of the Stormlight Archive',
+            author: 'Brandon Sanderson',
+          },
+        },
+      },
+      { asin: null, isbn: '9781429952040' },
+      'Rhythm of War: Book Four of the Stormlight Archive',
+      'Brandon Sanderson',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'rhythm-book');
+    assert.equal(result.editionId, 'different-duration-audiobook');
+  });
+});


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It selects the listened audiobook edition using format and duration evidence rather than accepting the first identifier hit.

- prefer audiobook editions that match Audiobookshelf listening duration
- derive duration from Audiobookshelf file metadata when needed
- rank every listened candidate before selecting an edition
- Related: #153, #181

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/auto-add-audiobook-edition-selection.test.js tests/audiobook-duration-extraction.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A