### PR TITLE
fix(matching): rescore identifier search editions

### DIFF
--- a/src/matching/book-matcher.js
+++ b/src/matching/book-matcher.js
@@ -15,6 +15,8 @@ import { TitleAuthorMatcher } from './strategies/title-author-matcher.js';
 import {
   extractTitle,
   extractAuthor,
+  extractNarrator,
+  extractAudioDurationFromAudiobookshelf,
   detectUserBookFormat,
 } from './utils/audiobookshelf-extractor.js';
 import { getIsbnVariants, normalizeAsin } from './utils/text-matching.js';
@@ -359,6 +361,18 @@ export class BookMatcher {
               sourceFormat,
               matchType,
             );
+          } else if (
+            strategy.getTier() <= 2 &&
+            match._isSearchResult
+          ) {
+            const sourceFormat = detectUserBookFormat(absBook);
+            const matchType = match._matchType || 'identifier_search_result';
+            match = await this._enhanceIdentifierSearchResultEdition(
+              match,
+              absBook,
+              sourceFormat,
+              matchType,
+            );
           }
 
           logger.debug(
@@ -576,6 +590,107 @@ export class BookMatcher {
       _upgradeReason: hasLength
         ? 'format_match_improvement'
         : 'length_data_enrichment',
+      _scoreImprovement: result.improvement,
+    };
+  }
+
+  /**
+   * Treat a new identifier result as work-level evidence when its exact
+   * edition has the wrong format or lacks format-appropriate length data.
+   * This keeps exact, usable audiobook matches untouched while allowing a
+   * print/ebook ISBN to resolve to the best audiobook edition on that work.
+   */
+  async _enhanceIdentifierSearchResultEdition(
+    match,
+    absBook,
+    sourceFormat = null,
+    matchType = 'identifier_search_result',
+  ) {
+    const currentEdition = match?.edition;
+    const bookId = match?.book?.id || currentEdition?.book?.id;
+    if (!currentEdition || !bookId) {
+      return match;
+    }
+
+    const currentFormat = this.formatMapper
+      ? this.formatMapper(currentEdition)
+      : currentEdition.format || currentEdition.reading_format?.format;
+    const hasExpectedLength =
+      sourceFormat === 'audiobook'
+        ? Number(currentEdition.audio_seconds) > 0
+        : Number(currentEdition.pages) > 0;
+
+    if (currentFormat === sourceFormat && hasExpectedLength) {
+      return match;
+    }
+
+    let book;
+    try {
+      book = await this.hardcoverClient.getBookDetailsWithEditions(bookId);
+    } catch (error) {
+      logger.warn('Failed to fetch editions for identifier search result', {
+        bookId,
+        editionId: currentEdition.id,
+        error: error.message,
+      });
+      return match;
+    }
+
+    if (!book?.editions?.length) {
+      return match;
+    }
+
+    const { selectBestEdition, PROFILES } =
+      await import('./utils/unified-edition-scorer.js');
+    const identifierProfile = {
+      ...PROFILES.TITLE_AUTHOR,
+      name: 'IDENTIFIER_SEARCH_RESULT',
+      minImprovement: 5,
+    };
+    const result = selectBestEdition(book.editions, {
+      sourceFormat,
+      sourceDuration: extractAudioDurationFromAudiobookshelf(absBook),
+      sourceNarrator: extractNarrator(absBook),
+      profile: identifierProfile,
+      currentEdition,
+      formatMapper: this.formatMapper,
+    });
+
+    if (!result?.edition || !result.shouldUpgrade) {
+      return match;
+    }
+
+    const selectedEdition = {
+      ...result.edition,
+      format:
+        result.edition.format ||
+        result.edition.reading_format?.format ||
+        result.edition.physical_format ||
+        'unknown',
+      book: currentEdition.book || {
+        id: book.id || bookId,
+        title: book.title,
+        contributions: book.contributions || [],
+      },
+    };
+
+    logger.info('Upgraded identifier search result to ABS-aware edition', {
+      bookId,
+      originalEditionId: currentEdition.id,
+      selectedEditionId: selectedEdition.id,
+      sourceFormat,
+      selectedFormat: selectedEdition.format,
+      scoreImprovement: result.improvement.toFixed(1),
+    });
+
+    return {
+      ...match,
+      edition: selectedEdition,
+      book: match.book || selectedEdition.book,
+      _originalEditionId: currentEdition.id,
+      _matchType: `${matchType}_cross_edition_enriched`,
+      _editionUpgraded: true,
+      _upgradeReason: 'identifier_work_edition_selection',
       _scoreImprovement: result.improvement,
     };
   }

--- a/src/matching/book-matcher.js
+++ b/src/matching/book-matcher.js
@@ -361,10 +361,7 @@ export class BookMatcher {
               sourceFormat,
               matchType,
             );
-          } else if (
-            strategy.getTier() <= 2 &&
-            match._isSearchResult
-          ) {
+          } else if (strategy.getTier() <= 2 && match._isSearchResult) {
             const sourceFormat = detectUserBookFormat(absBook);
             const matchType = match._matchType || 'identifier_search_result';
             match = await this._enhanceIdentifierSearchResultEdition(

--- a/tests/identifier-search-result-edition.test.js
+++ b/tests/identifier-search-result-edition.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { BookMatcher } from '../src/matching/book-matcher.js';
+
+function createMatcher(hardcoverClient) {
+  const matcher = new BookMatcher(hardcoverClient, null, {});
+  matcher.formatMapper = edition => {
+    const format = edition.reading_format?.format;
+    return format === 'Listened' ? 'audiobook' : 'ebook';
+  };
+  return matcher;
+}
+
+describe('Identifier search-result edition selection', () => {
+  it('uses an ISBN to identify the work and selects the duration-matched audiobook edition', async () => {
+    const exactIsbnEdition = {
+      id: 30432880,
+      pages: 624,
+      reading_format: { format: 'Ebook' },
+      book: { id: 427383, title: 'The Well of Ascension' },
+    };
+    const audiobookEdition = {
+      id: 30616150,
+      audio_seconds: 80084,
+      reading_format: { format: 'Listened' },
+      users_count: 3,
+    };
+    const matcher = createMatcher({
+      getBookDetailsWithEditions: async () => ({
+        id: 427383,
+        title: 'The Well of Ascension',
+        editions: [exactIsbnEdition, audiobookEdition],
+      }),
+    });
+
+    const result = await matcher._enhanceIdentifierSearchResultEdition(
+      {
+        userBook: null,
+        edition: exactIsbnEdition,
+        _matchType: 'isbn_search_result',
+        _isSearchResult: true,
+      },
+      {
+        media: {
+          duration: 80088.55,
+          metadata: { narrator: 'Michael Kramer' },
+        },
+      },
+      'audiobook',
+      'isbn_search_result',
+    );
+
+    assert.equal(result.edition.id, 30616150);
+    assert.equal(result.edition.book.id, 427383);
+    assert.equal(result.edition.format, 'audiobook');
+    assert.equal(result._editionUpgraded, true);
+    assert.equal(result._originalEditionId, 30432880);
+  });
+
+  it('does not fetch alternatives for a usable exact audiobook result', async () => {
+    let fetchCount = 0;
+    const matcher = createMatcher({
+      getBookDetailsWithEditions: async () => {
+        fetchCount++;
+        return null;
+      },
+    });
+    const match = {
+      edition: {
+        id: 30404159,
+        audio_seconds: 49560,
+        reading_format: { format: 'Listened' },
+        book: { id: 427565, title: 'Ready Player Two' },
+      },
+      _isSearchResult: true,
+    };
+
+    const result = await matcher._enhanceIdentifierSearchResultEdition(
+      match,
+      { media: { duration: 49560 } },
+      'audiobook',
+      'asin_search_result',
+    );
+
+    assert.strictEqual(result, match);
+    assert.equal(fetchCount, 0);
+  });
+});


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It rescores editions returned by identifier searches so the selected result reflects the Audiobookshelf edition.

- score all editions attached to an identifier search result
- prefer edition metadata that best matches the source audiobook
- cover the identifier-result edition choice with a focused regression test
- Related: #181

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/identifier-search-result-edition.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A