### PR TITLE
fix(sync): align dry-run auto-add flow

### DIFF
--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2574,12 +2574,12 @@ export class SyncManager {
             },
             targetTitle: title,
             targetAuthor: author || 'N/A',
-            fallbackEnabled: !this.dryRun,
+            fallbackEnabled: true,
             titleAuthorId: titleAuthorId,
           },
         );
 
-        if (!this.dryRun) {
+        if (searchResults.length === 0) {
           try {
             // Use BookMatcher's title/author matching with library context
             // This enables duplicate detection and "Want to Read" update logic
@@ -2835,7 +2835,7 @@ export class SyncManager {
               `Could not find ${title} in Hardcover database after all search attempts`,
               {
                 searchedIdentifiers: identifiers,
-                titleAuthorAttempted: !this.dryRun,
+                titleAuthorAttempted: true,
                 dryRun: this.dryRun,
               },
             );

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2261,6 +2261,22 @@ export class SyncManager {
           syncResult.actions.push(
             `[DRY RUN] Would add matched book to library`,
           );
+
+          // Continue through the same post-add sync path as live mode without
+          // issuing a write to Hardcover.
+          if (!hardcoverMatch.userBook) {
+            hardcoverMatch.userBook = {
+              id: `dry-run-${bookId}`,
+              book: {
+                id: bookId,
+                title: hardcoverMatch.book?.title || title,
+                contributions: [],
+              },
+            };
+          } else {
+            hardcoverMatch.userBook.id = `dry-run-${bookId}`;
+          }
+          hardcoverMatch._isSearchResult = false;
         }
       } catch (error) {
         logger.error(

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2276,6 +2276,7 @@ export class SyncManager {
           } else {
             hardcoverMatch.userBook.id = `dry-run-${bookId}`;
           }
+          hardcoverMatch._isDryRunSimulatedAdd = true;
           hardcoverMatch._isSearchResult = false;
         }
       } catch (error) {
@@ -3229,7 +3230,16 @@ export class SyncManager {
 
       // Disable protection for force sync, or for first sync only when
       // Hardcover has no existing progress to protect.
-      if (shouldProtectAgainstRegression && isForceSync) {
+      if (
+        shouldProtectAgainstRegression &&
+        hardcoverMatch._isDryRunSimulatedAdd
+      ) {
+        shouldProtectAgainstRegression = false;
+        logger.debug(
+          `Skipping existing progress lookup for simulated addition: ${title}`,
+          { bookId: hardcoverMatch.book?.id },
+        );
+      } else if (shouldProtectAgainstRegression && isForceSync) {
         shouldProtectAgainstRegression = false;
         logger.debug(
           `Disabling progress regression protection for ${title}: force sync enabled`,

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -317,9 +317,12 @@ describe('Search-result auto-add guards', () => {
   it('continues a dry-run through the live post-add path without a second auto-add', async () => {
     const match = createTwoStageMatch();
     const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
-    const syncExistingBook = mock.fn(async () => ({
-      status: 'synced',
-      reason: 'dry-run sync preview',
+    const getBookCurrentProgress = mock.fn(async () => ({
+      has_progress: true,
+    }));
+    const handleCompletionStatus = mock.fn(async () => ({
+      status: 'completed',
+      reason: 'dry-run completion preview',
     }));
     const manager = Object.create(SyncManager.prototype);
 
@@ -343,8 +346,9 @@ describe('Search-result auto-add guards', () => {
         generateTitleAuthorIdentifier: () =>
           'title_author:the_martian|andy_weir',
         getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+        getSyncTracking: mock.fn(async () => ({ total_syncs: 2 })),
       },
-      hardcover: { addBookToLibrary },
+      hardcover: { addBookToLibrary, getBookCurrentProgress },
       sessionManager: {
         shouldDelayUpdate: mock.fn(async () => ({
           shouldDelay: false,
@@ -352,7 +356,8 @@ describe('Search-result auto-add guards', () => {
         })),
         completeSession: mock.fn(async () => false),
       },
-      _syncExistingBook: syncExistingBook,
+      _selectEditionWithCache: mock.fn(async () => match.edition),
+      _handleCompletionStatus: handleCompletionStatus,
       _clearNegativeSyncSkip: mock.fn(async () => {}),
     });
 
@@ -370,10 +375,12 @@ describe('Search-result auto-add guards', () => {
       null,
     );
 
-    assert.equal(result.status, 'synced');
+    assert.equal(result.status, 'completed');
     assert.equal(addBookToLibrary.mock.callCount(), 0);
-    assert.equal(syncExistingBook.mock.callCount(), 1);
+    assert.equal(getBookCurrentProgress.mock.callCount(), 0);
+    assert.equal(handleCompletionStatus.mock.callCount(), 1);
     assert.equal(match._isSearchResult, false);
+    assert.equal(match._isDryRunSimulatedAdd, true);
     assert.equal(match.userBook.id, 'dry-run-292354');
     assert.equal(match.userBook.book.id, 292354);
     assert.equal(match.edition.id, 30402186);

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -314,6 +314,71 @@ describe('Search-result auto-add guards', () => {
     assert.equal(addBookToLibrary.mock.callCount(), 0);
   });
 
+  it('continues a dry-run through the live post-add path without a second auto-add', async () => {
+    const match = createTwoStageMatch();
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+    const syncExistingBook = mock.fn(async () => ({
+      status: 'synced',
+      reason: 'dry-run sync preview',
+    }));
+    const manager = Object.create(SyncManager.prototype);
+
+    Object.assign(manager, {
+      userId: 'test-user',
+      dryRun: true,
+      verbose: false,
+      timezone: 'UTC',
+      globalConfig: {
+        force_sync: true,
+        auto_add_books: true,
+        min_progress_threshold: 5,
+      },
+      bookMatcher: {
+        findMatch: mock.fn(async () => ({
+          match,
+          extractedMetadata: {},
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_martian|andy_weir',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      hardcover: { addBookToLibrary },
+      sessionManager: {
+        shouldDelayUpdate: mock.fn(async () => ({
+          shouldDelay: false,
+          reason: 'dry-run sync preview',
+        })),
+        completeSession: mock.fn(async () => false),
+      },
+      _syncExistingBook: syncExistingBook,
+      _clearNegativeSyncSkip: mock.fn(async () => {}),
+    });
+
+    const result = await manager._syncSingleBook(
+      {
+        id: 'abs-the-martian',
+        progress_percentage: 100,
+        media: {
+          metadata: {
+            title: 'The Martian',
+            authors: [{ name: 'Andy Weir' }],
+          },
+        },
+      },
+      null,
+    );
+
+    assert.equal(result.status, 'synced');
+    assert.equal(addBookToLibrary.mock.callCount(), 0);
+    assert.equal(syncExistingBook.mock.callCount(), 1);
+    assert.equal(match._isSearchResult, false);
+    assert.equal(match.userBook.id, 'dry-run-292354');
+    assert.equal(match.userBook.book.id, 292354);
+    assert.equal(match.edition.id, 30402186);
+  });
+
   it('caches the edition ID from a two-stage match', async () => {
     const storeEditionMapping = mock.fn(async () => {});
     const matcher = new TitleAuthorMatcher(null, { storeEditionMapping }, {});

--- a/tests/sync-manager-dry-run-isbn-search.test.js
+++ b/tests/sync-manager-dry-run-isbn-search.test.js
@@ -78,4 +78,67 @@ describe('SyncManager dry-run ISBN search', () => {
     assert.equal(searchBooksByIsbn.mock.calls[0].arguments[0], isbn);
     assert.equal(addBookToLibrary.mock.callCount(), 0);
   });
+
+  it('uses read-only title/author fallback results in dry-run mode', async () => {
+    const title = 'New Spring';
+    const findMatchByTitleAuthor = mock.fn(async () => ({
+      userBook: null,
+      book: { id: 'hardcover-book-new-spring', title },
+      edition: {
+        id: 'hardcover-edition-new-spring',
+        book: { id: 'hardcover-book-new-spring', title },
+        audio_seconds: 43740,
+        reading_format: { format: 'Listened' },
+      },
+      _matchType: 'title_author_two_stage',
+      _isSearchResult: true,
+    }));
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      hardcoverBooks: [],
+      globalConfig: { force_sync: false },
+      hardcover: {
+        searchBooksByAsin: mock.fn(async () => []),
+        searchBooksByIsbn: mock.fn(async () => []),
+        addBookToLibrary,
+      },
+      bookMatcher: { findMatchByTitleAuthor },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:new_spring|robert_jordan',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+
+    const result = await SyncManager.prototype._tryAutoAddBook.call(
+      manager,
+      {
+        id: 'abs-new-spring',
+        media: {
+          metadata: {
+            title,
+            author: 'Robert Jordan',
+            asin: 'B072325KCX',
+          },
+        },
+      },
+      { asin: 'B072325KCX', isbn: null },
+      title,
+      'Robert Jordan',
+    );
+
+    assert.equal(result.status, 'auto_added');
+    assert.equal(result.bookId, 'hardcover-book-new-spring');
+    assert.equal(result.editionId, 'hardcover-edition-new-spring');
+    assert.equal(findMatchByTitleAuthor.mock.callCount(), 1);
+    assert.equal(addBookToLibrary.mock.callCount(), 0);
+  });
 });

--- a/tests/sync-manager-dry-run-isbn-search.test.js
+++ b/tests/sync-manager-dry-run-isbn-search.test.js
@@ -116,6 +116,13 @@ describe('SyncManager dry-run ISBN search', () => {
       _mapHardcoverFormatToInternal:
         SyncManager.prototype._mapHardcoverFormatToInternal,
       _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+      _getEditionProgressBasis: SyncManager.prototype._getEditionProgressBasis,
+      _isEditionProgressCapable:
+        SyncManager.prototype._isEditionProgressCapable,
+      _selectProgressCapableEdition:
+        SyncManager.prototype._selectProgressCapableEdition,
+      _resolveProgressCapableAutoAddEdition:
+        SyncManager.prototype._resolveProgressCapableAutoAddEdition,
     };
 
     const result = await SyncManager.prototype._tryAutoAddBook.call(


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It makes dry-run auto-adds exercise the same matching decisions as live syncs without performing writes or post-add progress lookups.

- preview title fallback and search-result auto-add decisions in dry runs
- return a simulated successful add through the normal sync flow
- skip progress lookup for additions that were only simulated
- Related: #171

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/sync-manager-dry-run-isbn-search.test.js tests/search-result-auto-add-guards.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A