### PR TITLE
fix(sync): make auto-add reservations retryable

### DIFF
--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -30,6 +30,7 @@ export class SyncManager {
     const workers = this.globalConfig.workers || 3;
     this.taskQueue = new TaskQueue({ concurrency: workers });
     this.abortController = new AbortController();
+    this.autoAddReservations = new Map();
 
     this.timezone = globalConfig.timezone || 'UTC';
 
@@ -97,6 +98,7 @@ export class SyncManager {
 
   async syncProgress() {
     const startTime = Date.now();
+    this.autoAddReservations.clear();
     logger.info('Starting sync for user', {
       service: 'shelfbridge',
       version: currentVersion,
@@ -2955,6 +2957,33 @@ export class SyncManager {
       };
       const bookId = editionResolution.book.id;
       const editionId = edition.id;
+      const reservationKey = String(bookId);
+      this.autoAddReservations ||= new Map();
+      const existingReservation =
+        this.autoAddReservations.get(reservationKey);
+
+      if (existingReservation) {
+        logger.info(`Skipping duplicate auto-add within current sync`, {
+          title,
+          bookId,
+          editionId,
+          reservedByTitle: existingReservation.title,
+          reservedEditionId: existingReservation.editionId,
+        });
+        return {
+          status: 'skipped',
+          reason: `Book ${bookId} already reserved for auto-add in this sync`,
+          title,
+          bookId,
+          editionId,
+          duplicate: true,
+        };
+      }
+
+      this.autoAddReservations.set(reservationKey, {
+        title,
+        editionId,
+      });
 
       logger.debug(`Found match in Hardcover`, {
         title: title,

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -19,6 +19,65 @@ import { Transaction } from './utils/transaction.js';
 import SessionManager from './session-manager.js';
 import { currentVersion } from './version.js';
 
+async function acquireAutoAddReservation(manager, bookId, title, editionId) {
+  const reservationKey = String(bookId);
+  manager.autoAddReservations ||= new Map();
+
+  while (true) {
+    const existingReservation = manager.autoAddReservations.get(reservationKey);
+    if (!existingReservation) {
+      let resolveCompletion;
+      const completion = new Promise(resolve => {
+        resolveCompletion = resolve;
+      });
+      const reservation = {
+        title,
+        editionId,
+        completion,
+        resolveCompletion,
+        settled: false,
+      };
+      manager.autoAddReservations.set(reservationKey, reservation);
+      return { acquired: true, reservationKey, reservation };
+    }
+
+    if (!existingReservation.completion) {
+      return {
+        acquired: false,
+        reservationKey,
+        existingReservation,
+      };
+    }
+
+    const succeeded = await existingReservation.completion;
+    if (succeeded) {
+      return {
+        acquired: false,
+        reservationKey,
+        existingReservation,
+      };
+    }
+  }
+}
+
+function settleAutoAddReservation(
+  manager,
+  reservationKey,
+  reservation,
+  succeeded,
+) {
+  if (!reservation || reservation.settled) return;
+
+  reservation.settled = true;
+  if (
+    !succeeded &&
+    manager.autoAddReservations?.get(reservationKey) === reservation
+  ) {
+    manager.autoAddReservations.delete(reservationKey);
+  }
+  reservation.resolveCompletion(succeeded);
+}
+
 export class SyncManager {
   constructor(user, globalConfig, dryRun = false, verbose = false) {
     this.user = user;
@@ -2213,10 +2272,14 @@ export class SyncManager {
       hardcoverMatch.edition = editionResolution.edition;
       editionId = editionResolution.edition.id;
 
-      const reservationKey = String(bookId);
-      this.autoAddReservations ||= new Map();
-      const existingReservation = this.autoAddReservations.get(reservationKey);
-      if (existingReservation) {
+      const reservationState = await acquireAutoAddReservation(
+        this,
+        bookId,
+        title,
+        editionId,
+      );
+      if (!reservationState.acquired) {
+        const { existingReservation } = reservationState;
         logger.info(`Skipping duplicate auto-add within current sync`, {
           title,
           bookId,
@@ -2232,7 +2295,6 @@ export class SyncManager {
         syncResult.timing = performance.now() - startTime;
         return syncResult;
       }
-      this.autoAddReservations.set(reservationKey, { title, editionId });
 
       try {
         if (!this.dryRun) {
@@ -2249,6 +2311,12 @@ export class SyncManager {
           );
 
           if (addResult && addResult.id) {
+            settleAutoAddReservation(
+              this,
+              reservationState.reservationKey,
+              reservationState.reservation,
+              true,
+            );
             syncResult.actions.push(`Added matched book to Hardcover library`);
 
             // Update the match object to look like a regular library match
@@ -2264,7 +2332,12 @@ export class SyncManager {
             }
             hardcoverMatch._isSearchResult = false; // No longer just a search result
           } else {
-            this.autoAddReservations.delete(reservationKey);
+            settleAutoAddReservation(
+              this,
+              reservationState.reservationKey,
+              reservationState.reservation,
+              false,
+            );
             logger.error(
               `Failed to add title/author matched book to library: API returned null`,
               {
@@ -2285,9 +2358,20 @@ export class SyncManager {
           syncResult.actions.push(
             `[DRY RUN] Would add matched book to library`,
           );
+          settleAutoAddReservation(
+            this,
+            reservationState.reservationKey,
+            reservationState.reservation,
+            true,
+          );
         }
       } catch (error) {
-        this.autoAddReservations.delete(reservationKey);
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          false,
+        );
         logger.error(
           `Failed to add title/author matched book to library: ${error.message}`,
         );
@@ -2474,6 +2558,8 @@ export class SyncManager {
       title: title,
       dryRun: this.dryRun,
     });
+
+    let reservationState = null;
 
     try {
       let searchResults = [];
@@ -2980,11 +3066,15 @@ export class SyncManager {
       };
       const bookId = editionResolution.book.id;
       const editionId = edition.id;
-      const reservationKey = String(bookId);
-      this.autoAddReservations ||= new Map();
-      const existingReservation = this.autoAddReservations.get(reservationKey);
+      reservationState = await acquireAutoAddReservation(
+        this,
+        bookId,
+        title,
+        editionId,
+      );
 
-      if (existingReservation) {
+      if (!reservationState.acquired) {
+        const { existingReservation } = reservationState;
         logger.info(`Skipping duplicate auto-add within current sync`, {
           title,
           bookId,
@@ -3002,11 +3092,6 @@ export class SyncManager {
         };
       }
 
-      this.autoAddReservations.set(reservationKey, {
-        title,
-        editionId,
-      });
-
       logger.debug(`Found match in Hardcover`, {
         title: title,
         hardcoverTitle: edition.book.title,
@@ -3020,6 +3105,12 @@ export class SyncManager {
       if (this.dryRun) {
         logger.debug(
           `[DRY RUN] Would add ${title} to library (book_id: ${bookId}, edition_id: ${editionId})`,
+        );
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          true,
         );
         return { status: 'auto_added', title, bookId, editionId };
       }
@@ -3040,6 +3131,12 @@ export class SyncManager {
       );
 
       if (addResult) {
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          true,
+        );
         logger.info(`Successfully added ${title} to library`, {
           userBookId: addResult.id,
           hardcoverTitle: edition.book.title,
@@ -3168,6 +3265,12 @@ export class SyncManager {
           throw cacheError;
         }
       } else {
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          false,
+        );
         logger.error(`Failed to add ${title} to library`, {
           bookId: bookId,
           editionId: editionId,
@@ -3175,6 +3278,14 @@ export class SyncManager {
         return { status: 'error', reason: 'Failed to add to library', title };
       }
     } catch (error) {
+      if (reservationState?.acquired) {
+        settleAutoAddReservation(
+          this,
+          reservationState.reservationKey,
+          reservationState.reservation,
+          false,
+        );
+      }
       logger.error(`Error auto-adding ${title}`, {
         error: error.message,
         stack: error.stack,

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -2213,6 +2213,27 @@ export class SyncManager {
       hardcoverMatch.edition = editionResolution.edition;
       editionId = editionResolution.edition.id;
 
+      const reservationKey = String(bookId);
+      this.autoAddReservations ||= new Map();
+      const existingReservation = this.autoAddReservations.get(reservationKey);
+      if (existingReservation) {
+        logger.info(`Skipping duplicate auto-add within current sync`, {
+          title,
+          bookId,
+          editionId,
+          reservedByTitle: existingReservation.title,
+          reservedEditionId: existingReservation.editionId,
+        });
+        syncResult.actions.push(
+          `Skipped duplicate auto-add for Hardcover book ${bookId}`,
+        );
+        syncResult.status = 'skipped';
+        syncResult.reason = `Book ${bookId} already reserved for auto-add in this sync`;
+        syncResult.timing = performance.now() - startTime;
+        return syncResult;
+      }
+      this.autoAddReservations.set(reservationKey, { title, editionId });
+
       try {
         if (!this.dryRun) {
           logger.debug(`Adding title/author matched book to library`, {
@@ -2243,6 +2264,7 @@ export class SyncManager {
             }
             hardcoverMatch._isSearchResult = false; // No longer just a search result
           } else {
+            this.autoAddReservations.delete(reservationKey);
             logger.error(
               `Failed to add title/author matched book to library: API returned null`,
               {
@@ -2265,6 +2287,7 @@ export class SyncManager {
           );
         }
       } catch (error) {
+        this.autoAddReservations.delete(reservationKey);
         logger.error(
           `Failed to add title/author matched book to library: ${error.message}`,
         );
@@ -2959,8 +2982,7 @@ export class SyncManager {
       const editionId = edition.id;
       const reservationKey = String(bookId);
       this.autoAddReservations ||= new Map();
-      const existingReservation =
-        this.autoAddReservations.get(reservationKey);
+      const existingReservation = this.autoAddReservations.get(reservationKey);
 
       if (existingReservation) {
         logger.info(`Skipping duplicate auto-add within current sync`, {

--- a/tests/auto-add-run-deduplication.test.js
+++ b/tests/auto-add-run-deduplication.test.js
@@ -3,74 +3,161 @@ import { describe, it, mock } from 'node:test';
 
 import { SyncManager } from '../src/sync-manager.js';
 
+const hardcoverBook = { id: 'lost-metal-book', title: 'The Lost Metal' };
+const identifiers = { asin: 'B09N7MXRNZ', isbn: null };
+
+function createAbsBook(id, duration = 67620) {
+  return {
+    id,
+    media: {
+      audioFiles: [{ duration }],
+      metadata: {
+        title: 'The Lost Metal: A Mistborn Novel',
+        author: 'Brandon Sanderson',
+      },
+    },
+  };
+}
+
+function createManager({
+  dryRun = false,
+  addBookToLibrary = mock.fn(),
+  storeBookSyncData = mock.fn(async () => {}),
+} = {}) {
+  return {
+    userId: 'test-user',
+    dryRun,
+    globalConfig: { force_sync: false },
+    autoAddReservations: new Map(),
+    hardcover: {
+      searchBooksByAsin: mock.fn(async () => [
+        {
+          id: 'lost-metal-audio',
+          asin: 'B09N7MXRNZ',
+          audio_seconds: 67620,
+          reading_format: { format: 'Listened' },
+          book: hardcoverBook,
+        },
+      ]),
+      searchBooksByIsbn: mock.fn(async () => []),
+      addBookToLibrary,
+    },
+    cache: {
+      generateTitleAuthorIdentifier: () =>
+        'title_author:the_lost_metal|brandon_sanderson',
+      getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      storeBookSyncData,
+    },
+    _checkFormatCompatibility: SyncManager.prototype._checkFormatCompatibility,
+    _mapHardcoverFormatToInternal:
+      SyncManager.prototype._mapHardcoverFormatToInternal,
+    _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    _getEditionProgressBasis: SyncManager.prototype._getEditionProgressBasis,
+    _isEditionProgressCapable: SyncManager.prototype._isEditionProgressCapable,
+    _selectProgressCapableEdition:
+      SyncManager.prototype._selectProgressCapableEdition,
+    _resolveProgressCapableAutoAddEdition:
+      SyncManager.prototype._resolveProgressCapableAutoAddEdition,
+  };
+}
+
+function tryAutoAdd(manager, id) {
+  return SyncManager.prototype._tryAutoAddBook.call(
+    manager,
+    createAbsBook(id),
+    identifiers,
+    'The Lost Metal: A Mistborn Novel',
+    'Brandon Sanderson',
+  );
+}
+
 describe('Within-run auto-add deduplication', () => {
   it('reserves a Hardcover book before concurrent dry-run additions', async () => {
-    const hardcoverBook = { id: 'lost-metal-book', title: 'The Lost Metal' };
-    const searchBooksByAsin = mock.fn(async () => [
-      {
-        id: 'lost-metal-audio',
-        asin: 'B09N7MXRNZ',
-        audio_seconds: 67620,
-        reading_format: { format: 'Listened' },
-        book: hardcoverBook,
-      },
-    ]);
-    const manager = {
-      userId: 'test-user',
-      dryRun: true,
-      globalConfig: { force_sync: false },
-      autoAddReservations: new Map(),
-      hardcover: {
-        searchBooksByAsin,
-        searchBooksByIsbn: mock.fn(async () => []),
-        addBookToLibrary: mock.fn(),
-      },
-      cache: {
-        generateTitleAuthorIdentifier: () =>
-          'title_author:the_lost_metal|brandon_sanderson',
-        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
-      },
-      _checkFormatCompatibility:
-        SyncManager.prototype._checkFormatCompatibility,
-      _mapHardcoverFormatToInternal:
-        SyncManager.prototype._mapHardcoverFormatToInternal,
-      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
-    };
-    const createAbsBook = (id, duration) => ({
-      id,
-      media: {
-        audioFiles: [{ duration }],
-        metadata: {
-          title: 'The Lost Metal: A Mistborn Novel',
-          author: 'Brandon Sanderson',
-        },
-      },
-    });
-    const identifiers = { asin: 'B09N7MXRNZ', isbn: null };
+    const manager = createManager({ dryRun: true });
 
     const results = await Promise.all([
-      SyncManager.prototype._tryAutoAddBook.call(
-        manager,
-        createAbsBook('abs-lost-metal-standard', 67620),
-        identifiers,
-        'The Lost Metal: A Mistborn Novel',
-        'Brandon Sanderson',
-      ),
-      SyncManager.prototype._tryAutoAddBook.call(
-        manager,
-        createAbsBook('abs-lost-metal-full-cast', 56822),
-        identifiers,
-        'The Lost Metal: A Mistborn Novel',
-        'Brandon Sanderson',
-      ),
+      tryAutoAdd(manager, 'abs-lost-metal-standard'),
+      tryAutoAdd(manager, 'abs-lost-metal-full-cast'),
     ]);
 
-    assert.deepEqual(
-      results.map(result => result.status).sort(),
-      ['auto_added', 'skipped'],
-    );
+    assert.deepEqual(results.map(result => result.status).sort(), [
+      'auto_added',
+      'skipped',
+    ]);
     assert.equal(results.filter(result => result.duplicate).length, 1);
     assert.equal(manager.autoAddReservations.size, 1);
     assert.equal(manager.hardcover.addBookToLibrary.mock.callCount(), 0);
+  });
+
+  it('releases a reservation when the add returns null', async () => {
+    const addBookToLibrary = mock.fn(async () => null);
+    const manager = createManager({ addBookToLibrary });
+
+    const first = await tryAutoAdd(manager, 'abs-first');
+    const second = await tryAutoAdd(manager, 'abs-second');
+
+    assert.equal(first.status, 'error');
+    assert.equal(second.status, 'error');
+    assert.equal(addBookToLibrary.mock.callCount(), 2);
+    assert.equal(manager.autoAddReservations.size, 0);
+  });
+
+  it('releases a reservation when the add throws', async () => {
+    const addBookToLibrary = mock.fn(async () => {
+      throw new Error('temporary add failure');
+    });
+    const manager = createManager({ addBookToLibrary });
+
+    const first = await tryAutoAdd(manager, 'abs-first');
+    const second = await tryAutoAdd(manager, 'abs-second');
+
+    assert.equal(first.status, 'error');
+    assert.equal(second.status, 'error');
+    assert.equal(addBookToLibrary.mock.callCount(), 2);
+    assert.equal(manager.autoAddReservations.size, 0);
+  });
+
+  it('lets a concurrent duplicate retry after the owner add fails', async () => {
+    let resolveFirstAdd;
+    const firstAdd = new Promise(resolve => {
+      resolveFirstAdd = resolve;
+    });
+    const addBookToLibrary = mock.fn(async () => {
+      if (addBookToLibrary.mock.callCount() === 1) return firstAdd;
+      return null;
+    });
+    const manager = createManager({ addBookToLibrary });
+
+    const firstPromise = tryAutoAdd(manager, 'abs-first');
+    await new Promise(resolve => setImmediate(resolve));
+    const secondPromise = tryAutoAdd(manager, 'abs-second');
+    resolveFirstAdd(null);
+    const results = await Promise.all([firstPromise, secondPromise]);
+
+    assert.deepEqual(
+      results.map(result => result.status),
+      ['error', 'error'],
+    );
+    assert.equal(addBookToLibrary.mock.callCount(), 2);
+    assert.equal(manager.autoAddReservations.size, 0);
+  });
+
+  it('retains the reservation after a successful add if caching fails', async () => {
+    const addBookToLibrary = mock.fn(async () => ({ id: 'user-book-1' }));
+    const manager = createManager({
+      addBookToLibrary,
+      storeBookSyncData: mock.fn(async () => {
+        throw new Error('cache unavailable');
+      }),
+    });
+
+    const first = await tryAutoAdd(manager, 'abs-first');
+    const second = await tryAutoAdd(manager, 'abs-second');
+
+    assert.equal(first.status, 'error');
+    assert.equal(second.status, 'skipped');
+    assert.equal(second.duplicate, true);
+    assert.equal(addBookToLibrary.mock.callCount(), 1);
+    assert.equal(manager.autoAddReservations.size, 1);
   });
 });

--- a/tests/auto-add-run-deduplication.test.js
+++ b/tests/auto-add-run-deduplication.test.js
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Within-run auto-add deduplication', () => {
+  it('reserves a Hardcover book before concurrent dry-run additions', async () => {
+    const hardcoverBook = { id: 'lost-metal-book', title: 'The Lost Metal' };
+    const searchBooksByAsin = mock.fn(async () => [
+      {
+        id: 'lost-metal-audio',
+        asin: 'B09N7MXRNZ',
+        audio_seconds: 67620,
+        reading_format: { format: 'Listened' },
+        book: hardcoverBook,
+      },
+    ]);
+    const manager = {
+      userId: 'test-user',
+      dryRun: true,
+      globalConfig: { force_sync: false },
+      autoAddReservations: new Map(),
+      hardcover: {
+        searchBooksByAsin,
+        searchBooksByIsbn: mock.fn(async () => []),
+        addBookToLibrary: mock.fn(),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_lost_metal|brandon_sanderson',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      _checkFormatCompatibility:
+        SyncManager.prototype._checkFormatCompatibility,
+      _mapHardcoverFormatToInternal:
+        SyncManager.prototype._mapHardcoverFormatToInternal,
+      _areFormatsCompatible: SyncManager.prototype._areFormatsCompatible,
+    };
+    const createAbsBook = (id, duration) => ({
+      id,
+      media: {
+        audioFiles: [{ duration }],
+        metadata: {
+          title: 'The Lost Metal: A Mistborn Novel',
+          author: 'Brandon Sanderson',
+        },
+      },
+    });
+    const identifiers = { asin: 'B09N7MXRNZ', isbn: null };
+
+    const results = await Promise.all([
+      SyncManager.prototype._tryAutoAddBook.call(
+        manager,
+        createAbsBook('abs-lost-metal-standard', 67620),
+        identifiers,
+        'The Lost Metal: A Mistborn Novel',
+        'Brandon Sanderson',
+      ),
+      SyncManager.prototype._tryAutoAddBook.call(
+        manager,
+        createAbsBook('abs-lost-metal-full-cast', 56822),
+        identifiers,
+        'The Lost Metal: A Mistborn Novel',
+        'Brandon Sanderson',
+      ),
+    ]);
+
+    assert.deepEqual(
+      results.map(result => result.status).sort(),
+      ['auto_added', 'skipped'],
+    );
+    assert.equal(results.filter(result => result.duplicate).length, 1);
+    assert.equal(manager.autoAddReservations.size, 1);
+    assert.equal(manager.hardcover.addBookToLibrary.mock.callCount(), 0);
+  });
+});

--- a/tests/search-result-auto-add-guards.test.js
+++ b/tests/search-result-auto-add-guards.test.js
@@ -314,6 +314,74 @@ describe('Search-result auto-add guards', () => {
     assert.equal(addBookToLibrary.mock.callCount(), 0);
   });
 
+  it('reserves direct search-result additions before concurrent records can add the same work', async () => {
+    const syncExistingBook = mock.fn(async () => ({
+      status: 'completed',
+      reason: 'dry-run completion preview',
+    }));
+    const manager = Object.create(SyncManager.prototype);
+
+    Object.assign(manager, {
+      userId: 'test-user',
+      dryRun: true,
+      verbose: false,
+      timezone: 'UTC',
+      autoAddReservations: new Map(),
+      globalConfig: {
+        force_sync: true,
+        auto_add_books: true,
+        min_progress_threshold: 5,
+      },
+      bookMatcher: {
+        findMatch: mock.fn(async () => ({
+          match: createTwoStageMatch(),
+          extractedMetadata: {},
+        })),
+      },
+      cache: {
+        generateTitleAuthorIdentifier: () =>
+          'title_author:the_martian|andy_weir',
+        getCachedBookInfo: mock.fn(async () => ({ exists: false })),
+      },
+      hardcover: { addBookToLibrary: mock.fn() },
+      sessionManager: {
+        shouldDelayUpdate: mock.fn(async () => ({
+          shouldDelay: false,
+          reason: 'test sync',
+        })),
+        completeSession: mock.fn(async () => false),
+      },
+      _syncExistingBook: syncExistingBook,
+      _clearNegativeSyncSkip: mock.fn(async () => {}),
+    });
+    const createAbsBook = id => ({
+      id,
+      progress_percentage: 100,
+      media: {
+        metadata: {
+          title: 'The Martian',
+          authors: [{ name: 'Andy Weir' }],
+        },
+      },
+    });
+
+    const results = await Promise.all([
+      manager._syncSingleBook(createAbsBook('abs-standard'), null),
+      manager._syncSingleBook(createAbsBook('abs-full-cast'), null),
+    ]);
+
+    assert.deepEqual(results.map(result => result.status).sort(), [
+      'completed',
+      'skipped',
+    ]);
+    assert.equal(syncExistingBook.mock.callCount(), 1);
+    assert.equal(manager.autoAddReservations.size, 1);
+    assert.match(
+      results.find(result => result.status === 'skipped').reason,
+      /already reserved for auto-add/,
+    );
+  });
+
   it('caches the edition ID from a two-stage match', async () => {
     const storeEditionMapping = mock.fn(async () => {});
     const matcher = new TitleAuthorMatcher(null, { storeEditionMapping }, {});


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It prevents duplicate auto-adds within one sync run while allowing a failed attempt to be retried.

- reserve auto-add targets before concurrent sync work
- apply the same reservation to direct search-result additions
- release failed reservations so later candidates can retry
- Related: #171

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/auto-add-run-deduplication.test.js tests/search-result-auto-add-guards.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A