### PR TITLE
fix(reporting): report successful book updates

### DIFF
--- a/src/display/SyncResultFormatter.js
+++ b/src/display/SyncResultFormatter.js
@@ -179,32 +179,29 @@ export class SyncResultFormatter {
     ];
 
     const successfulStatuses = new Set(['synced', 'completed', 'auto_added']);
-    const detailedSuccessfulBookUpdates =
+    const detailedSuccessfulBooks =
       Array.isArray(result.book_details) && result.book_details.length > 0
         ? result.book_details.filter(book =>
             successfulStatuses.has(book.status),
           ).length
         : null;
-    const successfulBookUpdates =
-      detailedSuccessfulBookUpdates ??
+    const successfulBooks =
+      detailedSuccessfulBooks ??
       result.books_synced + result.books_completed + result.books_auto_added;
-    const skippedCalls = result.books_skipped;
+    const skippedBooks = result.books_skipped;
 
     if (isDryRun) {
       // In dry-run mode, show what would happen
-      rightColumn.push(`├─ ${successfulBookUpdates} would be updated`);
+      rightColumn.push(`├─ ${successfulBooks} would be updated`);
       rightColumn.push(`├─ 0 API calls made (dry run)`);
       rightColumn.push(`├─ ${result.errors.length} would fail`);
-      rightColumn.push(`└─ ${skippedCalls} skipped (no changes)`);
+      rightColumn.push(`└─ ${skippedBooks} skipped (no changes)`);
     } else {
-      const updateLabel =
-        successfulBookUpdates === 1 ? 'book update' : 'book updates';
-      const errorLabel =
-        result.errors.length === 1 ? 'processing error' : 'processing errors';
-
-      rightColumn.push(`├─ ${successfulBookUpdates} successful ${updateLabel}`);
-      rightColumn.push(`├─ ${result.errors.length} ${errorLabel}`);
-      rightColumn.push(`└─ ${skippedCalls} skipped (no changes)`);
+      // Normal mode, show actual results
+      const bookLabel = successfulBooks === 1 ? 'book' : 'books';
+      rightColumn.push(`├─ ${successfulBooks} ${bookLabel} updated`);
+      rightColumn.push(`├─ ${result.errors.length} failed`);
+      rightColumn.push(`└─ ${skippedBooks} skipped (no changes)`);
     }
 
     return rightColumn;

--- a/src/display/SyncResultFormatter.js
+++ b/src/display/SyncResultFormatter.js
@@ -178,7 +178,15 @@ export class SyncResultFormatter {
       isDryRun ? '🌐 Hardcover Updates (DRY RUN)' : '🌐 Hardcover Updates',
     ];
 
+    const successfulStatuses = new Set(['synced', 'completed', 'auto_added']);
+    const detailedSuccessfulBookUpdates =
+      Array.isArray(result.book_details) && result.book_details.length > 0
+        ? result.book_details.filter(book =>
+            successfulStatuses.has(book.status),
+          ).length
+        : null;
     const successfulBookUpdates =
+      detailedSuccessfulBookUpdates ??
       result.books_synced + result.books_completed + result.books_auto_added;
     const skippedCalls = result.books_skipped;
 

--- a/src/sync-manager.js
+++ b/src/sync-manager.js
@@ -3916,6 +3916,15 @@ export class SyncManager {
   _updateResult(result, syncResult) {
     result.books_processed++;
 
+    const recordedAutoAdd = (syncResult.actions || []).some(
+      action =>
+        action === 'Added matched book to Hardcover library' ||
+        action === '[DRY RUN] Would add matched book to library',
+    );
+    if (recordedAutoAdd) {
+      result.books_auto_added++;
+    }
+
     // Create detailed book info for verbose output
     const bookDetail = {
       title: syncResult.title || 'Unknown Title',
@@ -3959,7 +3968,9 @@ export class SyncManager {
         result.books_completed++;
         break;
       case 'auto_added':
-        result.books_auto_added++;
+        if (!recordedAutoAdd) {
+          result.books_auto_added++;
+        }
         break;
       case 'skipped':
         result.books_skipped++;

--- a/tests/sync-result-auto-add-reporting.test.js
+++ b/tests/sync-result-auto-add-reporting.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { SyncResultFormatter } from '../src/display/SyncResultFormatter.js';
+import { SyncManager } from '../src/sync-manager.js';
+
+describe('Post-add sync reporting', () => {
+  it('counts a simulated add that continues to completion without double-counting updated books', () => {
+    const manager = Object.create(SyncManager.prototype);
+    const result = {
+      books_processed: 0,
+      books_synced: 0,
+      books_completed: 0,
+      books_auto_added: 0,
+      books_skipped: 0,
+      books_delayed: 0,
+      errors: [],
+      book_details: [],
+    };
+
+    manager._updateResult(result, {
+      title: 'Ready Player Two',
+      status: 'completed',
+      actions: ['[DRY RUN] Would add matched book to library'],
+      errors: [],
+    });
+
+    assert.equal(result.books_processed, 1);
+    assert.equal(result.books_completed, 1);
+    assert.equal(result.books_auto_added, 1);
+
+    const formatter = new SyncResultFormatter();
+    const output = formatter._buildHardcoverUpdatesColumn(result, {
+      dry_run: true,
+    });
+    assert.ok(output.includes('├─ 1 would be updated'));
+  });
+});

--- a/tests/sync-result-auto-add-reporting.test.js
+++ b/tests/sync-result-auto-add-reporting.test.js
@@ -34,5 +34,14 @@ describe('Post-add sync reporting', () => {
       dry_run: true,
     });
     assert.ok(output.includes('├─ 1 would be updated'));
+
+    const liveOutput = formatter._buildHardcoverUpdatesColumn(result, {
+      dry_run: false,
+    });
+    assert.ok(liveOutput.includes('├─ 1 book updated'));
+    assert.equal(
+      liveOutput.some(line => line.includes('API calls made')),
+      false,
+    );
   });
 });

--- a/tests/sync-result-formatter-integration.test.js
+++ b/tests/sync-result-formatter-integration.test.js
@@ -280,8 +280,8 @@ describe('SyncResultFormatter Integration with DisplayLogger', () => {
         { dry_run: false },
       );
 
-      assert(lines.includes('├─ 1 successful book update'));
-      assert(lines.includes('├─ 1 processing error'));
+      assert(lines.includes('├─ 1 book updated'));
+      assert(lines.includes('├─ 1 failed'));
       assert(lines.includes('└─ 25 skipped (no changes)'));
       assert.equal(
         lines.some(line => line.includes('API calls made')),


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It separates successful book updates from skipped items and counts post-add syncs as auto-add successes.

- count an auto-added book after its post-add sync succeeds
- label successful book updates explicitly in the summary
- keep rejected and failed match reporting distinct
- Related: #142

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/sync-result-auto-add-reporting.test.js tests/sync-result-formatter-integration.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A