### PR TITLE
fix(cache): align session recovery and transaction timeout

### DIFF
--- a/src/book-cache.js
+++ b/src/book-cache.js
@@ -529,7 +529,7 @@ export class BookCache {
     let originalBusyTimeout;
     try {
       // Get current busy timeout and set a new one
-      originalBusyTimeout = this.db.pragma('busy_timeout', true);
+      originalBusyTimeout = this.db.pragma('busy_timeout', { simple: true });
       this.db.pragma(`busy_timeout = ${timeout}`);
     } catch (error) {
       logger.debug(`Could not set database timeout: ${error.message}`);

--- a/src/main.js
+++ b/src/main.js
@@ -568,7 +568,7 @@ async function processStartupSessions(users, globalConfig) {
       });
 
       // Initialize cache to check for active sessions
-      const cache = new BookCache(`data/.book_cache_${user.id}.db`);
+      const cache = new BookCache();
       await cache.init();
 
       // Get all active sessions for this user

--- a/tests/book-cache-transaction-timeout.test.js
+++ b/tests/book-cache-transaction-timeout.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { BookCache } from '../src/book-cache.js';
+
+describe('BookCache transaction timeout', () => {
+  it('applies and restores the configured SQLite busy timeout', async () => {
+    const cache = new BookCache(':memory:');
+    await cache.init();
+
+    try {
+      cache.db.pragma('busy_timeout = 1234');
+      const results = await cache.executeTransaction(
+        [() => cache.db.pragma('busy_timeout', { simple: true })],
+        { timeout: 4321, description: 'timeout regression test' },
+      );
+
+      assert.deepEqual(results, [4321]);
+      assert.equal(
+        cache.db.pragma('busy_timeout', { simple: true }),
+        1234,
+      );
+    } finally {
+      cache.close();
+    }
+  });
+});

--- a/tests/book-cache-transaction-timeout.test.js
+++ b/tests/book-cache-transaction-timeout.test.js
@@ -16,10 +16,7 @@ describe('BookCache transaction timeout', () => {
       );
 
       assert.deepEqual(results, [4321]);
-      assert.equal(
-        cache.db.pragma('busy_timeout', { simple: true }),
-        1234,
-      );
+      assert.equal(cache.db.pragma('busy_timeout', { simple: true }), 1234);
     } finally {
       cache.close();
     }

--- a/tests/startup-cache-path.test.js
+++ b/tests/startup-cache-path.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+
+describe('Startup cache path', () => {
+  it('uses the same shared cache for session recovery and normal syncs', () => {
+    const mainSource = readFileSync('./src/main.js', 'utf8');
+    const syncManagerSource = readFileSync('./src/sync-manager.js', 'utf8');
+
+    assert.match(
+      mainSource,
+      /processStartupSessions[\s\S]*?const cache = new BookCache\(\);/,
+    );
+    assert.match(syncManagerSource, /this\.cache = new BookCache\(\);/);
+    assert.doesNotMatch(mainSource, /\.book_cache_\$\{user\.id\}\.db/);
+  });
+});


### PR DESCRIPTION
## Summary

This is an independent slice of #218, split out at the maintainer's request to reduce review and merge risk. It keeps startup session recovery on the configured shared cache and applies the configured busy timeout to cache transactions.

- reuse the shared cache path during session recovery
- configure transaction busy timeout consistently
- add focused startup and transaction regression coverage

## Scope

- [x] This PR has one reviewable objective
- [x] Follow-up work, stacked PRs, or intentionally deferred changes are called out here: the remaining #218 fixes are being submitted as separate draft PRs

## Checklist

- [x] Tests added or updated
- [ ] `README.md` or `docs/` updated if install, deployment, config, or user-facing behavior changed — N/A, no documentation or configuration contract changes
- [ ] `template.env` updated if environment variables or example config changed — N/A
- [ ] `CHANGELOG.md` updated in ## [Unreleased] section — N/A, release-note handling is deferred to the maintainer

## Test plan

- [ ] `tests/run-all.sh` — N/A, this repository uses `scripts/run-test-suite.js`
- [x] Focused test(s):
    - `node --test tests/startup-cache-path.test.js tests/book-cache-transaction-timeout.test.js`
- [ ] Docker or Compose validation, if container behavior changed — N/A